### PR TITLE
v1.0.1b1 - Bugfix: https://github.com/oracle/dbt-oracle/issues/4

### DIFF
--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -182,9 +182,6 @@
         {% if relation.schema %}
         and table_schema = upper('{{ relation.schema }}')
         {% endif %}
-        {% if relation.database %}
-        and table_catalog = upper('{{ relation.database }}')
-        {% endif %}
       order by ordinal_position
 
   {% endcall %}
@@ -341,7 +338,6 @@
     end as "kind"
   from tables
   where table_type in ('BASE TABLE', 'VIEW')
-    and table_catalog = upper('{{ schema_relation.database }}')
     and table_schema = upper('{{ schema_relation.schema }}')
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
@@ -359,4 +355,10 @@
                                 path={"identifier": tmp_identifier}) -%}
 
     {% do return(tmp_relation) %}
+{% endmacro %}
+
+{% macro get_database_name() %}
+    {% set results = run_query("select UPPER(SYS_CONTEXT('userenv', 'DB_NAME')) FROM DUAL") %}
+    {% set db_name = results.columns[0].values()[0] %}
+    {{ return(db_name) }}
 {% endmacro %}

--- a/dbt/include/oracle/macros/catalog.sql
+++ b/dbt/include/oracle/macros/catalog.sql
@@ -22,6 +22,9 @@
       But we won't fail in the case where there are multiple quoting-difference-only dbs, which is better.
     #}
     {% set database = information_schema.database %}
+    {% if database == 'None' or database is undefined or database is none %}
+      {% set database = get_database_name() %}
+    {% endif %}
     {{ adapter.verify_database(database) }}
 
     with columns as (

--- a/dbt/include/oracle/macros/materializations/snapshot/snapshot.sql
+++ b/dbt/include/oracle/macros/materializations/snapshot/snapshot.sql
@@ -208,12 +208,17 @@
   {%- set strategy_name = config.get('strategy') -%}
   {%- set unique_key = config.get('unique_key') %}
 
-  {% if not adapter.check_schema_exists(model.database, model.schema) %}
-    {% do create_schema(model.database, model.schema) %}
+  {% set model_database = model.database %}
+  {% if model_database == 'None' or model_database is undefined or model_database is none %}
+    {% set model_database = get_database_name() %}
+  {% endif %}
+
+  {% if not adapter.check_schema_exists(model_database, model.schema) %}
+    {% do create_schema(model_database, model.schema) %}
   {% endif %}
 
   {% set target_relation_exists, target_relation = get_or_create_relation(
-          database=model.database,
+          database=model_database,
           schema=model.schema,
           identifier=target_table,
           type='table') -%}

--- a/dbt/include/oracle/macros/materializations/snapshot/strategies.sql
+++ b/dbt/include/oracle/macros/materializations/snapshot/strategies.sql
@@ -77,8 +77,13 @@
         {{ return([false, query_columns]) }}
     {%- endif -%}
     {# handle any schema changes #}
+    {% set node_database = node.database %}
+    {% if node_database == 'None' or model_database is undefined or model_database is none %}
+        {% set node_database = get_database_name() %}
+    {% endif %}
     {%- set target_table = node.get('alias', node.get('name')) -%}
-    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=target_table) -%}
+
+    {%- set target_relation = adapter.get_relation(database=node_database, schema=node.schema, identifier=target_table) -%}
     {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation.quote(schema=False, identifier=False)) -%}
     {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}
     {%- set ns.column_added = false -%}

--- a/dbt_adbs_test_project/profiles.yml
+++ b/dbt_adbs_test_project/profiles.yml
@@ -9,7 +9,7 @@ dbt_test:
          host: "{{ env_var('DBT_ORACLE_HOST') }}"
          port: 1522
          service: "{{ env_var('DBT_ORACLE_SERVICE') }}"
-         database: "{{ env_var('DBT_ORACLE_DATABASE') }}"
+         #database: "{{ env_var('DBT_ORACLE_DATABASE') }}"
          schema: "{{ env_var('DBT_ORACLE_SCHEMA') }}"
          shardingkey:
            - skey

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dbt-oracle
-version = 1.0.0
+version = 1.0.1b1
 description = dbt (data build tool) adapter for the Oracle database
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ project_urls = {
     'Bug Tracker': 'https://github.com/oracle/dbt-oracle/issues'
 }
 
-VERSION='1.0.0'
+VERSION='1.0.1b1'
 setup(
     author="Oracle",
     python_requires='>=3.6',


### PR DESCRIPTION
1. database param is optional. You can drop it from profiles.yml
2. Introduced a new macro get_database_name() which can be used if database param is missing
3. Overrides adapter methods - list_relations_without_caching(), get_relation()
4. Override catalog specific method - _get_one_catalog()
5. Modified snapshot macros to invoke get_database_name() if database param is missing