### PR TITLE
v1.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ tests/oracle_1TLS.dbtspec
 doc/.docenv
 doc/build.gitbak
 .gitbak/
+.venvpy37

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dbt-core==0.21.1; python_version < '3.7'
-dbt-core==1.0.6; python_version >= '3.7'
+dbt-core==1.0.7; python_version >= '3.7'
 dataclasses; python_version < '3.7'
 cx_Oracle==8.3.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dbt-oracle
-version = 1.0.1
+version = 1.0.2
 description = dbt (data build tool) adapter for the Oracle database
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -31,7 +31,7 @@ packages = find:
 include_package_data = True
 install_requires =
     dbt-core==0.21.1; python_version < '3.7'
-    dbt-core==1.0.6; python_version >= '3.7'
+    dbt-core==1.0.7; python_version >= '3.7'
     cx_Oracle==8.3.0
     dataclasses; python_version < '3.7'
 test_suite=tests

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('README.md') as readme_file:
 
 requirements = [
         "dbt-core==0.21.1; python_version < '3.7'",
-        "dbt-core==1.0.6; python_version >= '3.7'",
+        "dbt-core==1.0.7; python_version >= '3.7'",
         "cx_Oracle==8.3.0",
         "dataclasses; python_version < '3.7'"
 ]
@@ -43,7 +43,7 @@ project_urls = {
 
 url = 'https://github.com/oracle/dbt-oracle'
 
-VERSION='1.0.1'
+VERSION='1.0.2'
 setup(
     author="Oracle",
     python_requires='>=3.6',


### PR DESCRIPTION
- `networkx` a dependency of `dbt-core` just released a version `2.8.1` which is incompatible with Python 3.7
- `dbt-core` v1.0.7 fixes this by defining a conditional dependency on `networkx` based on the Python 3 version