### PR TITLE
Fix/clean global temporary table

### DIFF
--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -268,9 +268,12 @@
 {% endmacro %}
 
 {% macro oracle__truncate_relation(relation) -%}
-  {% call statement('truncate_relation') -%}
-    truncate table {{ relation.quote(schema=False, identifier=False) }}
-  {%- endcall %}
+  {#-- To avoid `ORA-01702: a view is not appropriate here` we check that the relation to be truncated is a table #}
+  {% if relation.is_table %}
+    {% call statement('truncate_relation') -%}
+        truncate table {{ relation.quote(schema=False, identifier=False) }}
+    {%- endcall %}
+  {% endif %}
 {% endmacro %}
 
 {% macro oracle__rename_relation(from_relation, to_relation) -%}

--- a/dbt/include/oracle/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/oracle/macros/materializations/incremental/incremental.sql
@@ -62,6 +62,7 @@
   {% do adapter.commit() %}
 
   {% for rel in to_drop %}
+      {% do adapter.truncate_relation(rel) %}
       {% do adapter.drop_relation(rel) %}
   {% endfor %}
 

--- a/dbt/include/oracle/macros/materializations/snapshot/snapshot.sql
+++ b/dbt/include/oracle/macros/materializations/snapshot/snapshot.sql
@@ -35,8 +35,9 @@
   {{ adapter.dispatch('post_snapshot')(staging_relation) }}
 {% endmacro %}
 
-{% macro default__post_snapshot(staging_relation) %}
-    {# no-op #}
+{% macro oracle__post_snapshot(staging_relation) %}
+    {% do adapter.truncate_relation(staging_relation) %}
+    {% do adapter.drop_relation(staging_relation) %}
 {% endmacro %}
 
 


### PR DESCRIPTION
- dbt functionalities `Incremental materialization` and `Snapshots` use temporary tables to stage new data (delta). The data  from the temp table is either merged or inserted into the target table. 
- These temp tables are bound to the session and are automatically truncated after the session exits, however they were never dropped. 
- This fix first truncates the temporary table and then drops it.
- There is an additional check added in `oracle__truncate_relation` macro to avoid  `ORA-01702: a view is not appropriate here`