### PR TITLE
Update adapters.sql

### DIFF
--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -26,9 +26,6 @@
 {% endmacro %}
 
 {% macro oracle__create_schema(database_name, schema_name) -%}
-  {% if relation.database -%}
-    {{ adapter.verify_database(relation.database) }}
-  {%- endif -%}
   {%- call statement('drop_schema') -%}
     -- Noop for not breaking tests, oracle
     -- schemas are actualy users, we can't
@@ -275,7 +272,7 @@
 
 {% macro oracle__rename_relation(from_relation, to_relation) -%}
   {% call statement('rename_relation') -%}
-    rename {{ from_relation.include(False, False, True).quote(schema=False, identifier=False) }} to {{ to_relation.include(False, False, True).quote(schema=False, identifier=False) }}
+    alter table {{ from_relation.include(False, True, True).quote(schema=False, identifier=False) }} rename to {{ to_relation.include(False, False, True).quote(schema=False, identifier=False) }}
   {%- endcall %}
 {% endmacro %}
 


### PR DESCRIPTION
changes are to address issues when using custom schemas

1 - create schema call verifies database. As of 1.0.7 Oracle adapter allows for database parm not to be set since Oracle doesn't allow statement prefix to include database name. Trickle down effect of that change is 'create schema check' not working hence why lines are removed. There is even dummy-noop already in that method since you can't create schemas dbt-way in oracle (schemas are users). 

2 - once #1 is addressed and custom schema is used, rename command will not find temp model table since schema is not passed as part of rename statement. Furthermore, rename statement will not work because Oracle doesn't support renaming tables that way. Alter Table to the rescue.

changed from 
rename <table_original_name> to <table_new_name>

to

alter table <schema>.<original_name> rename to <table_new_name>


tested with 
Python 3.9.1
dbt-core 1.0.7
dbt-oracle 1.0.2