### PR TITLE
Fix/manage objects in different schema

### DIFF
--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -25,11 +25,11 @@
     {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}
 {% endmacro %}
 
-{% macro oracle__create_schema(database_name, schema_name) -%}
+{% macro oracle__create_schema(relation, schema_name) -%}
   {% if relation.database -%}
     {{ adapter.verify_database(relation.database) }}
   {%- endif -%}
-  {%- call statement('drop_schema') -%}
+  {%- call statement('create_schema') -%}
     -- Noop for not breaking tests, oracle
     -- schemas are actualy users, we can't
     -- create it here
@@ -121,7 +121,7 @@
   {%- set sql_header = config.get('sql_header', none) -%}
 
   {{ sql_header if sql_header is not none }}
-  create view {{ relation.quote(schema=False, identifier=False)  }} as
+  create or replace view {{ relation.include(False, True, True).quote(schema=False, identifier=False)  }} as
     {{ sql }}
 
 {% endmacro %}
@@ -204,7 +204,7 @@
 {% macro oracle__alter_relation_comment(relation, comment) %}
   {% set escaped_comment = oracle_escape_comment(comment) %}
   {# "comment on table" even for views #}
-  comment on table {{ relation.quote(schema=False, identifier=False) }} is {{ escaped_comment }}
+  comment on table {{ relation.include(False, True, True).quote(schema=False, identifier=False) }} is {{ escaped_comment }}
 {% endmacro %}
 
 {% macro oracle__persist_docs(relation, model, for_relation, for_columns) -%}
@@ -217,7 +217,7 @@
       {% set comment = column_dict[column_name]['description'] %}
       {% set escaped_comment = oracle_escape_comment(comment) %}
       {% call statement('alter _column comment', fetch_result=False) -%}
-        comment on column {{ relation.quote(schema=False, identifier=False) }}.{{ column_name }} is {{ escaped_comment }}
+        comment on column {{ relation.include(False, True, True).quote(schema=False, identifier=False) }}.{{ column_name }} is {{ escaped_comment }}
       {%- endcall %}
     {% endfor %}
   {% endif %}
@@ -233,16 +233,16 @@
   {%- set tmp_column = column_name + "__dbt_alter" -%}
 
   {% call statement('alter_column_type 1', fetch_result=False) %}
-    alter table {{ relation.quote(schema=False, identifier=False) }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }}
+    alter table {{ relation.include(False, True, True).quote(schema=False, identifier=False) }} add column {{ tmp_column }} {{ new_column_type }}
   {% endcall %}
   {% call statement('alter_column_type 2', fetch_result=False) %}
-    update {{ relation.quote(schema=False, identifier=False)  }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }}
+    update {{ relation.include(False, True, True).quote(schema=False, identifier=False)  }} set {{ tmp_column }} = {{ column_name }}
   {% endcall %}
   {% call statement('alter_column_type 3', fetch_result=False) %}
-    alter table {{ relation.quote(schema=False, identifier=False) }} drop column {{ adapter.quote(column_name) }} cascade
+    alter table {{ relation.include(False, True, True).quote(schema=False, identifier=False) }} drop column {{ column_name }} cascade
   {% endcall %}
   {% call statement('alter_column_type 4', fetch_result=False) %}
-    rename column {{ relation.quote(schema=False, identifier=False) }}.{{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}
+    alter table {{ relation.include(False, True, True).quote(schema=False, identifier=False) }} rename column {{ tmp_column }} to {{ column_name }}
   {% endcall %}
 
 {% endmacro %}
@@ -256,7 +256,7 @@
      pragma EXCEPTION_INIT(attempted_ddl_on_in_use_GTT, -14452);
   BEGIN
      SAVEPOINT start_transaction;
-     EXECUTE IMMEDIATE 'DROP {{ relation.type }} {{ relation.quote(schema=False, identifier=False) }} cascade constraint';
+     EXECUTE IMMEDIATE 'DROP {{ relation.type }} {{ relation.include(False, True, True).quote(schema=False, identifier=False) }} cascade constraint';
      COMMIT;
   EXCEPTION
      WHEN attempted_ddl_on_in_use_GTT THEN
@@ -271,14 +271,14 @@
   {#-- To avoid `ORA-01702: a view is not appropriate here` we check that the relation to be truncated is a table #}
   {% if relation.is_table %}
     {% call statement('truncate_relation') -%}
-        truncate table {{ relation.quote(schema=False, identifier=False) }}
+        truncate table {{ relation.include(False, True, True).quote(schema=False, identifier=False) }}
     {%- endcall %}
   {% endif %}
 {% endmacro %}
 
 {% macro oracle__rename_relation(from_relation, to_relation) -%}
   {% call statement('rename_relation') -%}
-    rename {{ from_relation.include(False, False, True).quote(schema=False, identifier=False) }} to {{ to_relation.include(False, False, True).quote(schema=False, identifier=False) }}
+    ALTER {{ from_relation.type }} {{ from_relation.include(False, True, True).quote(schema=False, identifier=False) }} rename to {{ to_relation.include(False, False, True).quote(schema=False, identifier=False) }}
   {%- endcall %}
 {% endmacro %}
 
@@ -355,7 +355,7 @@
     {% set dtstring = dt.strftime("%H%M%S") %}
     {% set tmp_identifier = 'o$pt_' ~ base_relation.identifier ~ dtstring %}
     {% set tmp_relation = base_relation.incorporate(
-                                path={"identifier": tmp_identifier}) -%}
+                                path={"identifier": tmp_identifier, "schema": None}) -%}
 
     {% do return(tmp_relation) %}
 {% endmacro %}
@@ -365,3 +365,4 @@
     {% set db_name = results.columns[0].values()[0] %}
     {{ return(db_name) }}
 {% endmacro %}
+

--- a/dbt/include/oracle/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/oracle/macros/materializations/incremental/incremental.sql
@@ -36,8 +36,11 @@
       {% set backup_identifier = existing_relation.identifier ~ "__dbt_backup" %}
       {% set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) %}
       {% do adapter.drop_relation(backup_relation) %}
-
-      {% do adapter.rename_relation(target_relation, backup_relation) %}
+      {% if existing_relation.is_view %}
+            {% do adapter.drop_relation(existing_relation) %}
+      {% else %}
+            {% do adapter.rename_relation(existing_relation, backup_relation) %}
+      {% endif %}
       {% set build_sql = create_table_as(False, target_relation, sql) %}
       {% do to_drop.append(backup_relation) %}
   {% else %}

--- a/dbt_adbs_test_project/macros/generate_schema_name.sql
+++ b/dbt_adbs_test_project/macros/generate_schema_name.sql
@@ -13,9 +13,13 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 #}
-{{config(materialized='table',
-         schema='dbt_test')}}
-SELECT * FROM {{ source('sh_database', 'countries')}}
-where country_iso_code in ('AT', 'BE', 'BG', 'DK', 'CZ', 'DE', 'IT',
-                           'FI', 'FR', 'GR', 'NL', 'IE', 'HU', 'ES', 'SE',
-                           'GE', 'IS', 'NO', 'CH', 'GB', 'VA')
+{% macro generate_schema_name(custom_schema_name, node) -%}
+
+    {%- set default_schema = target.schema -%}
+    {%- if custom_schema_name is none -%}
+        {{ default_schema }}
+    {%- else -%}
+        {{ custom_schema_name | trim }}
+    {%- endif -%}
+
+{%- endmacro %}

--- a/dbt_adbs_test_project/models/eu/countries.sql
+++ b/dbt_adbs_test_project/models/eu/countries.sql
@@ -14,7 +14,7 @@
   limitations under the License.
 #}
 {{config(materialized='table',
-         schema='dbt_test')}}
+         schema=env_var('DBT_ORACLE_CUSTOM_SCHEMA')) }}
 SELECT * FROM {{ source('sh_database', 'countries')}}
 where country_iso_code in ('AT', 'BE', 'BG', 'DK', 'CZ', 'DE', 'IT',
                            'FI', 'FR', 'GR', 'NL', 'IE', 'HU', 'ES', 'SE',

--- a/dbt_adbs_test_project/models/us_product_sales_channel_ranking.sql
+++ b/dbt_adbs_test_project/models/us_product_sales_channel_ranking.sql
@@ -16,11 +16,14 @@
 {{
     config(
         materialized='incremental',
-        unique_key='calendar_month_desc'
+        unique_key='group_id',
+        schema='dbt_test'
     )
 }}
 
-SELECT prod_name, channel_desc, calendar_month_desc, TO_CHAR(SUM(amount_sold), '9,999,999,999') SALES$,
+SELECT prod_name, channel_desc, calendar_month_desc,
+   {{ snapshot_hash_arguments(['prod_name', 'channel_desc', 'calendar_month_desc']) }} AS group_id,
+   TO_CHAR(SUM(amount_sold), '9,999,999,999') SALES$,
    RANK() OVER (ORDER BY SUM(amount_sold)) AS default_rank,
    RANK() OVER (ORDER BY SUM(amount_sold) DESC NULLS LAST) AS custom_rank
 FROM {{ source('sh_database', 'sales') }}, {{ source('sh_database', 'products') }}, {{ source('sh_database', 'customers') }},

--- a/dbt_adbs_test_project/models/us_product_sales_channel_ranking.sql
+++ b/dbt_adbs_test_project/models/us_product_sales_channel_ranking.sql
@@ -16,9 +16,7 @@
 {{
     config(
         materialized='incremental',
-        unique_key='group_id',
-        schema='dbt_test'
-    )
+        unique_key='group_id')
 }}
 
 SELECT prod_name, channel_desc, calendar_month_desc,


### PR DESCRIPTION
Added support for custom schema

  1. Following macros changed or fixed in adapter.sql to use custom schema name - oracle__create_schema, oracle__create_view_as, oracle__alter_relation_comment, oracle__alter_column_type, oracle__drop_relation, oracle__truncate_relation, oracle__rename_relation, oracle__make_temp_relation
  
  2. Changed view materialization strategy which unnecessarily created an intermediate <model>__dbt_tmp view first and renamed it to the target view. Now we directly CREATE or REPLACE view <target_view_name>
  
  3. Added generate_schema_name.sql as per dbt documentation in test project to determine the name of the schema that a model should be built in.
  
  4. Changed a couple of models in the test project to use custom schema
  
  5. Fixes Bug https://github.com/oracle/dbt-oracle/issues/14
  
  6. Fixes Bug https://github.com/oracle/dbt-oracle/issues/2
  
  7. Addresses issues raised in PR https://github.com/oracle/dbt-oracle/pull/15