### PR TITLE
Fix issue with incremental model merge not dropping global temp tables

### DIFF
--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -257,6 +257,9 @@
      pragma EXCEPTION_INIT(attempted_ddl_on_in_use_GTT, -14452);
   BEGIN
      SAVEPOINT start_transaction;
+     {% if relation.is_table -%}
+     EXECUTE IMMEDIATE 'TRUNCATE TABLE {{ relation.quote(schema=False, identifier=False) }}';
+     {%- endif -%}
      EXECUTE IMMEDIATE 'DROP {{ relation.type }} {{ relation.include(False, True, True).quote(schema=False, identifier=False) }} cascade constraint';
      COMMIT;
   EXCEPTION


### PR DESCRIPTION
with incremental models, oracle is not dropping global temp tables that are used as part of the merge process.
this will ensure in-use-exception will not occur as it will truncate table first and then drop it.

tested with:
python 3.9.1
dbt-core 1.0.7
dbt-oracle 1.0.2