### PR TITLE
Jinja whitespace control improvements

### DIFF
--- a/dbt/include/oracle/macros/materializations/incremental/helpers.sql
+++ b/dbt/include/oracle/macros/materializations/incremental/helpers.sql
@@ -45,15 +45,13 @@
     when matched then
       update set
       {% for col in dest_columns if col.name.upper() != unique_key.upper() -%}
-        target.{{ col.name }} = temp.{{ col.name }}
-        {% if not loop.last %}, {% endif %}
+        target.{{ col.name }} = temp.{{ col.name }}{% if not loop.last %}, {% endif %}
       {% endfor -%}
     when not matched then
       insert({{ dest_cols_csv }})
       values(
         {% for col in dest_columns -%}
-          temp.{{ col.name }}
-          {% if not loop.last %}, {% endif %}
+          temp.{{ col.name }}{% if not loop.last %}, {% endif %}
         {% endfor -%}
       )
     {%- else -%}

--- a/dbt/include/oracle/macros/materializations/incremental/helpers.sql
+++ b/dbt/include/oracle/macros/materializations/incremental/helpers.sql
@@ -44,23 +44,23 @@
       on (temp.{{ unique_key }} = target.{{ unique_key }})
     when matched then
       update set
-      {% for col in dest_columns if col.name.upper() != unique_key.upper() %}
+      {% for col in dest_columns if col.name.upper() != unique_key.upper() -%}
         target.{{ col.name }} = temp.{{ col.name }}
         {% if not loop.last %}, {% endif %}
-      {% endfor %}
+      {% endfor -%}
     when not matched then
-      insert( {{ dest_cols_csv }} )
+      insert({{ dest_cols_csv }})
       values(
-        {% for col in dest_columns %}
+        {% for col in dest_columns -%}
           temp.{{ col.name }}
           {% if not loop.last %}, {% endif %}
-        {% endfor %}
+        {% endfor -%}
       )
-    {%- else %}
+    {%- else -%}
     insert into {{ target_relation }} ({{ dest_cols_csv }})
     (
        select {{ dest_cols_csv }}
        from {{ tmp_relation }}
     )
-    {% endif %}
+    {%- endif -%}
 {%- endmacro %}


### PR DESCRIPTION
Produces more readable oracle incremental merge/upsert statement
```sql
    merge into myschema.test target
      using myschema.o$pt_test120014 temp
      on (temp.my_pk = target.my_pk)
    when matched then
      update set
      target.col1 = temp.col1,
      target.col2 = temp.col2,
      target.col3 = temp.col3
      
    when not matched then
      insert( my_pk, col1, col2, col3 )
      values(
        temp.my_pk,
        temp.col1,
        temp.col2,
        temp.col3
        
      )
```
instead of 
```sql
    merge into myschema.test target
      using myschema.o$pt_test120014 temp
      on (temp.my_pk = target.my_pk)
    when matched then
      update set
      
        target.col1 = temp.col1
        ,
      
        target.col2 = temp.col2
        ,
      
        target.col3 = temp.col3
        
      
    when not matched then
      insert( my_pk, col1, col2, col3 )
      values(
       
          temp.my_pk
          ,
       
          temp.col1
          ,
       
          temp.col2
          ,
       
          temp.col3
         
        
      )
```