### PR TITLE
Bumped dbt-core version to v1.0.8 for a critical security fix. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Configuration variables
-VERSION=1.0.3rc1
+VERSION=1.0.4
 PROJ_DIR?=$(shell pwd)
 VENV_DIR?=${PROJ_DIR}/.bldenv
 BUILD_DIR=${PROJ_DIR}/build
@@ -14,14 +14,33 @@ clean: clean_venv
 	rm -fr ${DIST_DIR}
 	rm -fr ${BUILD_DIR}
 
-
 wheel: clean
 	${PYTHON_3} -m venv ${VENV_DIR}
 	${VENV_DIR}/bin/pip install --upgrade wheel dataclasses build
 	${VENV_DIR}/bin/python3 -m build
 
+# Target to test dbt-oracle package in development environment.
+# This builds a wheel pkg from source in the current project directory and tests all dbt functionalities.
+adbs_local_env_test: wheel clean_venv
+	${PYTHON_3} -m venv ${VENV_DIR}
+	${VENV_DIR}/bin/pip install ${DIST_DIR}/dbt_oracle-${VERSION}-py3-none-any.whl
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt --version
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt debug --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt run-operation drop_schema --args 'relation: ${DBT_ORACLE_SCHEMA}' --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt deps --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt seed --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt run --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt test --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt test --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt run --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt snapshot --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt snapshot --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt docs generate --profiles-dir ./
+	cd dbt_adbs_test_project && ${VENV_DIR}/bin/dbt clean --profiles-dir ./
+
 
 # Target to test a dbt-oracle package from PyPI.
+# This installs a dbt-oracle from PyPI and tests all dbt functionalities
 adbs_pypi_test: clean_venv
 	${PYTHON_3} -m venv ${VENV_DIR}
 	${VENV_DIR}/bin/pip install dbt-oracle==${VERSION}

--- a/dbt/adapters/oracle/__version__.py
+++ b/dbt/adapters/oracle/__version__.py
@@ -14,4 +14,4 @@ Copyright (c) 2020, Vitor Avancini
   See the License for the specific language governing permissions and
   limitations under the License.
 """
-version = "1.0.7"
+version = "1.0.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dbt-oracle
-version = 1.0.3
+version = 1.0.4
 description = dbt (data build tool) adapter for the Oracle database
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -31,7 +31,7 @@ packages = find:
 include_package_data = True
 install_requires =
     dbt-core==0.21.1; python_version < '3.7'
-    dbt-core==1.0.7; python_version >= '3.7'
+    dbt-core==1.0.8; python_version >= '3.7'
     cx_Oracle==8.3.0
     dataclasses; python_version < '3.7'
 test_suite=tests

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('README.md') as readme_file:
 
 requirements = [
         "dbt-core==0.21.1; python_version < '3.7'",
-        "dbt-core==1.0.7; python_version >= '3.7'",
+        "dbt-core==1.0.8; python_version >= '3.7'",
         "cx_Oracle==8.3.0",
         "dataclasses; python_version < '3.7'"
 ]
@@ -43,7 +43,7 @@ project_urls = {
 
 url = 'https://github.com/oracle/dbt-oracle'
 
-VERSION='1.0.3'
+VERSION='1.0.4'
 setup(
     author="Oracle",
     python_requires='>=3.6',


### PR DESCRIPTION
1. Bumped dbt-core to v1.0.8 for critical security fix for rendering of secret env vars
2. Make target to build wheel and test in development mode within the project directory