### PR TITLE
Added support for connection retry params. 

### DIFF
--- a/dbt/adapters/oracle/connections.py
+++ b/dbt/adapters/oracle/connections.py
@@ -70,6 +70,10 @@ class OracleAdapterCredentials(Credentials):
     cclass: Optional[str] = None
     purity: Optional[str] = None
 
+    # Connection retry params
+    retry_count: Optional[int] = 1
+    retry_delay: Optional[int] = 3
+
 
     _ALIASES = {
         'dbname': 'database',
@@ -93,7 +97,8 @@ class OracleAdapterCredentials(Credentials):
             'protocol', 'host', 'port', 'tns_name',
             'service', 'connection_string',
             'shardingkey', 'supershardingkey',
-            'cclass', 'purity'
+            'cclass', 'purity', 'retry_count',
+            'retry_delay'
         )
 
     @classmethod
@@ -125,7 +130,7 @@ class OracleAdapterCredentials(Credentials):
             return self.connection_string
 
         # Assume host connection method OracleConnectionMethod.HOST and necessary parameters are defined
-        return f'{self.protocol}://{self.host}:{self.port}/{self.service}'
+        return f'{self.protocol}://{self.host}:{self.port}/{self.service}?retry_count={self.retry_count}&retry_delay={self.retry_delay}'
 
 
 class OracleAdapterConnectionManager(SQLConnectionManager):

--- a/dbt_adbs_test_project/profiles.yml
+++ b/dbt_adbs_test_project/profiles.yml
@@ -11,6 +11,8 @@ dbt_test:
          service: "{{ env_var('DBT_ORACLE_SERVICE') }}"
          #database: "{{ env_var('DBT_ORACLE_DATABASE') }}"
          schema: "{{ env_var('DBT_ORACLE_SCHEMA') }}"
+         retry_count: 1
+         retry_delay: 5
          shardingkey:
            - skey
          supershardingkey:

--- a/tests/functional/adapter/test_config.py
+++ b/tests/functional/adapter/test_config.py
@@ -56,7 +56,7 @@ SCENARIOS = {
                         port: 1522
                         threads: 1
             """,
-                    "dsn": "tcps://localhost:1522/xe",
+                    "dsn": "tcps://localhost:1522/xe?retry_count=1&retry_delay=3",
                 },
     "host_service": {
         "method": OracleConnectionMethod.HOST,
@@ -75,7 +75,7 @@ SCENARIOS = {
                         port: 1522
                         threads: 1
             """,
-        "dsn": "tcps://localhost:1522/xe_ha.host.tld",
+        "dsn": "tcps://localhost:1522/xe_ha.host.tld?retry_count=1&retry_delay=3",
     },
     "tns": {
         "method": OracleConnectionMethod.TNS,


### PR DESCRIPTION
These parameters are passed to the Python driver as-is

- `retry_count` :  Number of times to retry
- `retry_delay` : Time delay (in seconds) in between each retry

dbt can connect to the Oracle database using 3 different options

- If you use **TNS alias** to connect then retry params are included in the connect descriptor
   ```
    db2020_high = (description= (retry_count=40)(retry_delay=3)(address=(protocol=tcps)(port=1522)....
   ```

- If you use **Connect String** then you can include them in the connect string
   ```
    tcps://adb.oraclecloud.com:1522/example_high.adb.oraclecloud.com?retry_count=1&retry_delay=3
    
   ```

- If you use **host name or IP address** then you can define them in the profiles.yml
   ```yaml
   type: oracle
   user: "{{ env_var('DBT_ORACLE_USER') }}"
   pass: "{{ env_var('DBT_ORACLE_PASSWORD') }}"
   protocol: "tcps"
   host: "{{ env_var('DBT_ORACLE_HOST') }}"
   port: 1522
   service: "{{ env_var('DBT_ORACLE_SERVICE') }}"
   schema: "{{ env_var('DBT_ORACLE_SCHEMA') }}"
   retry_count: 1
   retry_delay: 5
   ```

