### PR TITLE
Added support for cross-database macros

### DIFF
--- a/dbt/include/oracle/macros/utils/cast_bool_to_text.sql
+++ b/dbt/include/oracle/macros/utils/cast_bool_to_text.sql
@@ -1,0 +1,23 @@
+{#
+ Copyright (c) 2022, Oracle and/or its affiliates.
+ Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{% macro oracle__cast_bool_to_text(bool_expression) %}
+    CASE
+        WHEN {{ bool_expression }} THEN 'true'
+        ELSE 'false'
+    END
+{% endmacro %}

--- a/dbt/include/oracle/macros/utils/dateadd.sql
+++ b/dbt/include/oracle/macros/utils/dateadd.sql
@@ -1,0 +1,31 @@
+{#
+ Copyright (c) 2022, Oracle and/or its affiliates.
+ Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{% macro oracle__dateadd(datepart, interval, from_date_or_timestamp) %}
+    {%- set single_quote = "\'" -%}
+    {%- set DS_INTERVAL_UNITS = ['DAY', 'HOUR', 'MINUTE', 'SECOND'] -%}
+    {%- set MY_INTERVAL_UNITS = ['YEAR','MONTH'] -%}
+    {%- if datepart.upper() in DS_INTERVAL_UNITS -%}
+        {{ from_date_or_timestamp }} + NUMTODSINTERVAL({{ interval }}, {{single_quote ~ datepart ~ single_quote}})
+    {%- elif datepart.upper() in MY_INTERVAL_UNITS -%}
+        {{ from_date_or_timestamp }} + NUMTOYMINTERVAL({{ interval }}, {{single_quote ~ datepart ~ single_quote}})
+    {%- elif datepart.upper() == 'QUARTER' -%}
+        ADD_MONTHS({{ from_date_or_timestamp }}, 3*{{ interval }})
+    {% elif datepart.upper() == 'WEEK' %}
+        {{ from_date_or_timestamp }} + 7*{{ interval }}
+    {%- endif -%}
+{% endmacro %}

--- a/dbt/include/oracle/macros/utils/datetrunc.sql
+++ b/dbt/include/oracle/macros/utils/datetrunc.sql
@@ -1,0 +1,27 @@
+{#
+ Copyright (c) 2022, Oracle and/or its affiliates.
+ Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{% macro oracle__date_trunc(datepart, date) %}
+    {% if datepart.upper() == 'QUARTER' %}
+        {% set datepart = 'Q' %}
+    {% endif %}
+    {% if datepart.upper() == 'WEEK' %}
+        {% set datepart = 'WW' %}
+    {% endif %}
+    {%- set single_quote = "\'" -%}
+    TRUNC({{date}}, {{single_quote ~ datepart ~ single_quote}})
+{% endmacro %}

--- a/dbt/include/oracle/macros/utils/except.sql
+++ b/dbt/include/oracle/macros/utils/except.sql
@@ -1,0 +1,20 @@
+{#
+ Copyright (c) 2022, Oracle and/or its affiliates.
+ Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{% macro oracle__except() %}
+    MINUS
+{% endmacro %}

--- a/dbt/include/oracle/macros/utils/hash.sql
+++ b/dbt/include/oracle/macros/utils/hash.sql
@@ -1,0 +1,21 @@
+{#
+ Copyright (c) 2022, Oracle and/or its affiliates.
+ Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{% macro oracle__hash(field, method='MD5') %}
+    {%- set single_quote = "\'" -%}
+    STANDARD_HASH({{field}}, {{single_quote ~ method  ~ single_quote }})
+{% endmacro %}

--- a/dbt/include/oracle/macros/utils/last_day.sql
+++ b/dbt/include/oracle/macros/utils/last_day.sql
@@ -1,0 +1,20 @@
+{#
+ Copyright (c) 2022, Oracle and/or its affiliates.
+ Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{% macro oracle__last_day(date, datepart) %}
+    {{dbt.dateadd('day', '-1', dbt.dateadd(datepart, '1', dbt.date_trunc(datepart, date)))}}
+{% endmacro %}

--- a/dbt/include/oracle/macros/utils/position.sql
+++ b/dbt/include/oracle/macros/utils/position.sql
@@ -1,0 +1,20 @@
+{#
+ Copyright (c) 2022, Oracle and/or its affiliates.
+ Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{% macro oracle__position(substring_text, string_text) %}
+    INSTR({{ string_text }}, {{ substring_text }})
+{% endmacro %}

--- a/dbt/include/oracle/macros/utils/right.sql
+++ b/dbt/include/oracle/macros/utils/right.sql
@@ -1,0 +1,29 @@
+{#
+ Copyright (c) 2022, Oracle and/or its affiliates.
+ Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+#}
+
+{% macro oracle__right(string_text, length_expression) %}
+
+    case when {{ length_expression }} = 0
+        then ''
+    else
+        substr(
+            {{ string_text }},
+            -1 * ({{ length_expression }})
+        )
+    end
+
+{%- endmacro -%}

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,6 @@
 filterwarnings =
     ignore:.*'soft_unicode' has been renamed to 'soft_str'*:DeprecationWarning
     ignore:unclosed file .*:ResourceWarning
+    ignore::RuntimeWarning
 testpaths =
     tests/functional

--- a/tests/functional/adapter/utils/test_common_utils.py
+++ b/tests/functional/adapter/utils/test_common_utils.py
@@ -1,0 +1,135 @@
+"""
+Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+"""
+
+import pytest
+
+from dbt.tests.adapter.utils.test_concat import BaseConcat
+from dbt.tests.adapter.utils.test_intersect import BaseIntersect
+from dbt.tests.adapter.utils.test_escape_single_quotes import BaseEscapeSingleQuotesQuote
+from dbt.tests.adapter.utils.test_except import BaseExcept
+from dbt.tests.adapter.utils.test_hash import BaseHash
+from dbt.tests.adapter.utils.test_string_literal import BaseStringLiteral
+from dbt.tests.adapter.utils.test_position import BasePosition
+from dbt.tests.adapter.utils.test_right import BaseRight
+from dbt.tests.adapter.utils.test_cast_bool_to_text import BaseCastBoolToText
+from dbt.tests.adapter.utils.test_replace import BaseReplace
+
+from dbt.tests.adapter.utils.fixture_cast_bool_to_text import models__test_cast_bool_to_text_yml
+from dbt.tests.adapter.utils.fixture_escape_single_quotes import models__test_escape_single_quotes_yml
+from dbt.tests.adapter.utils.fixture_string_literal import models__test_string_literal_yml
+
+
+# Oracle requires FROM DUAL
+models__test_escape_single_quotes_quote_sql = """
+select '{{ escape_single_quotes("they're") }}' as actual, 'they''re' as expected from dual union all
+select '{{ escape_single_quotes("they are") }}' as actual, 'they are' as expected from dual
+"""
+
+models__test_string_literal_sql = """
+select {{ string_literal("abc") }} as actual, 'abc' as expected from dual union all
+select {{ string_literal("1") }} as actual, '1' as expected from dual union all
+select {{ string_literal("") }} as actual, '' as expected from dual union all
+select {{ string_literal(none) }} as actual, 'None' as expected from dual
+"""
+
+# Oracle returns upper-case encoded MD5 hash
+seeds__data_hash_csv = """input_1,output
+ab,187EF4436122D1CC2F40DC2B92F0EBA0
+a,0CC175B9C0F1B6A831C399E269772661
+1,C4CA4238A0B923820DCC509A6F75849B
+,D41D8CD98F00B204E9800998ECF8427E
+"""
+
+models__test_cast_bool_to_text_sql = """
+with data as (
+
+    select 0 as input, 'false' as expected from dual union all 
+    select 1 as input, 'true' as expected from dual union all
+    select null as input, null as expected from dual
+
+)
+select
+    {{ cast_bool_to_text("input=1") }} actual,
+    expected
+from data
+"""
+
+class TestCastBoolToText(BaseCastBoolToText):
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_cast_bool_to_text.yml": models__test_cast_bool_to_text_yml,
+            "test_cast_bool_to_text.sql": self.interpolate_macro_namespace(
+                models__test_cast_bool_to_text_sql, "cast_bool_to_text"
+            ),
+        }
+
+
+class TestIntersect(BaseIntersect):
+    pass
+
+
+class TestConcat(BaseConcat):
+    pass
+
+
+class TestEscapeSingleQuotesQuote(BaseEscapeSingleQuotesQuote):
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_escape_single_quotes.yml": models__test_escape_single_quotes_yml,
+            "test_escape_single_quotes.sql": self.interpolate_macro_namespace(
+                models__test_escape_single_quotes_quote_sql, "escape_single_quotes"
+            ),
+        }
+
+
+class TestExcept(BaseExcept):
+    pass
+
+
+class TestHash(BaseHash):
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"data_hash.csv": seeds__data_hash_csv}
+
+
+class TestStringLiteral(BaseStringLiteral):
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_string_literal.yml": models__test_string_literal_yml,
+            "test_string_literal.sql": self.interpolate_macro_namespace(
+                models__test_string_literal_sql, "string_literal"
+            ),
+        }
+
+
+class TestStringPosition(BasePosition):
+    pass
+
+
+class TestStringRight(BaseRight):
+    pass
+
+
+# class TestStringReplace(BaseReplace):
+#     pass

--- a/tests/functional/adapter/utils/test_dateutils.py
+++ b/tests/functional/adapter/utils/test_dateutils.py
@@ -1,0 +1,83 @@
+"""
+Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2020, Vitor Avancini
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+"""
+
+import pytest
+from dbt.tests.adapter.utils.test_dateadd import BaseDateAdd
+from dbt.tests.adapter.utils.test_last_day import BaseLastDay
+from dbt.tests.adapter.utils.test_date_trunc import BaseDateTrunc
+
+from dbt.tests.adapter.utils.fixture_dateadd import models__test_dateadd_yml
+
+seeds__data_date_trunc_csv = """updated_at,day,month
+2018-01-05 12:00:00,2017-12-31 00:00:00,2018-01-01 00:00:00
+"""
+
+seeds__data_dateadd_csv = """start_date,interval_length,datepart,expected
+2018-01-20T01:00:00,1,day,2018-01-21T01:00:00
+2018-01-20T01:00:00,1,month,2018-02-20T01:00:00
+2018-01-20T01:00:00,1,year,2019-01-20T01:00:00
+2018-01-20T01:00:00,1,hour,2018-01-20T02:00:00
+2021-02-28T01:23:45,1,quarter,2021-05-31T01:23:45
+""".lstrip()
+
+
+models__test_dateadd_sql = """
+with data as (
+
+    select * from {{ ref('data_dateadd') }}
+
+)
+
+select
+    case
+        when datepart = 'hour' then {{ dateadd('hour', 'interval_length', 'start_date') }}
+        when datepart = 'day' then  {{ dateadd('day', 'interval_length', 'start_date') }}
+        when datepart = 'month' then {{ dateadd('month', 'interval_length', 'start_date') }}
+        when datepart = 'year' then  {{ dateadd('year', 'interval_length', 'start_date') }}
+        when datepart = 'quarter' then  {{ dateadd('quarter', 'interval_length', 'start_date') }}
+        else null
+    end as actual,
+    expected
+from data
+"""
+
+
+class TestDateAdd(BaseDateAdd):
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"data_dateadd.csv": seeds__data_dateadd_csv}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_dateadd.yml": models__test_dateadd_yml,
+            "test_dateadd.sql": self.interpolate_macro_namespace(
+                models__test_dateadd_sql, "dateadd"
+            ),
+        }
+
+
+class TestDateTrunc(BaseDateTrunc):
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"data_date_trunc.csv": seeds__data_date_trunc_csv}
+
+
+class TestLastDay(BaseLastDay):
+    pass


### PR DESCRIPTION
Following macros are implemented and tested in this PR

- String macros
  - concat
  - hash
  - position
  - right

- String literal macros
  - escape_single_quotes
  - string_literal

- Cast
  - cast_bool_to_text
 

- Date and Time
  - dateadd
  - date_trunc
  - last_day

- Set 
  - except
  - intersect