### PR TITLE
Release v1.3.1 changes

### DIFF
--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -348,7 +348,7 @@
 
 {% macro oracle__make_temp_relation(base_relation, suffix) %}
     {% set dt = modules.datetime.datetime.now() %}
-    {% set dtstring = dt.strftime("%H%M%S") %}
+    {% set dtstring = dt.strftime("%H%M%S%f") %}
     {% set tmp_identifier = 'o$pt_' ~ base_relation.identifier ~ dtstring %}
     {% set tmp_relation = base_relation.incorporate(
                                 path={"identifier": tmp_identifier, "schema": None}) -%}

--- a/dbt/include/oracle/macros/materializations/snapshot/strategies.sql
+++ b/dbt/include/oracle/macros/materializations/snapshot/strategies.sql
@@ -98,3 +98,23 @@
     {%- endfor -%}
     {{ return([ns.column_added, intersection]) }}
 {%- endmacro %}
+
+{% macro snapshot_timestamp_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}
+    {% set primary_key = config['unique_key'] %}
+    {% set updated_at = config['updated_at'] %}
+    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}
+
+    {% set row_changed_expr -%}
+        ({{ snapshotted_rel }}.dbt_valid_from < {{ current_rel }}.{{ updated_at }})
+    {%- endset %}
+    {# updated_at should be cast as timestamp because in hash computation "CAST(date as VARCHAR)" truncates time fields  #}
+    {% set scd_id_expr = snapshot_hash_arguments([primary_key, 'CAST(' ~ updated_at ~ ' AS TIMESTAMP)']) %}
+
+    {% do return({
+        "unique_key": primary_key,
+        "updated_at": updated_at,
+        "row_changed": row_changed_expr,
+        "scd_id": scd_id_expr,
+        "invalidate_hard_deletes": invalidate_hard_deletes
+    }) %}
+{% endmacro %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dbt-core==1.3.1
 cx_Oracle==8.3.0
-oracledb==1.2.0
+oracledb==1.2.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ include_package_data = True
 install_requires =
     dbt-core==1.3.1
     cx_Oracle==8.3.0
-    oracledb==1.2.0
+    oracledb==1.2.1
 test_suite=tests
 test_requires =
     dbt-tests-adapter==1.3.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open('README.md') as readme_file:
 requirements = [
         "dbt-core==1.3.1",
         "cx_Oracle==8.3.0",
-        "oracledb==1.2.0"
+        "oracledb==1.2.1"
 ]
 
 test_requirements = [


### PR DESCRIPTION
- Added `module` and `client_identifier` to trace dbt connection
- Bugfix for dbt snapshots https://github.com/oracle/dbt-oracle/issues/52
- oracledb dependency upgraded to 1.2.1
- Global temporary relation name includes milliseconds