### PR TITLE
Fixes and features for v1.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Configuration variables
-VERSION=1.3.1
+VERSION=1.3.2
 PROJ_DIR?=$(shell pwd)
 VENV_DIR?=${PROJ_DIR}/.bldenv
 BUILD_DIR=${PROJ_DIR}/build

--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -100,12 +100,13 @@
   {% if temporary -%} on commit preserve rows {%- endif %}
   as
     {{ sql }}
-
 {%- endmacro %}
 
 
 {% macro oracle__create_table_as(temporary, relation, sql) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
+  {%- set parallel = config.get('parallel', none) -%}
+  {%- set compression_clause = config.get('table_compression_clause', none) -%}
 
   {{ sql_header if sql_header is not none }}
 
@@ -113,6 +114,8 @@
     global temporary
   {%- endif %} table {{ relation.include(schema=(not temporary)) }}
   {% if temporary -%} on commit preserve rows {%- endif %}
+  {% if parallel %} parallel {{ parallel }}{% endif %}
+  {% if compression_clause %} {{ compression_clause }} {% endif %}
   as
     {{ sql }}
 

--- a/dbt/include/oracle/macros/materializations/table/table.sql
+++ b/dbt/include/oracle/macros/materializations/table/table.sql
@@ -17,8 +17,8 @@
 {% materialization table, adapter='oracle' %}
   {% set identifier = model['alias'] %}
   {% set grant_config = config.get('grants') %}
-  {% set tmp_identifier = model['name'] + '__dbt_tmp' %}
-  {% set backup_identifier = model['name'] + '__dbt_backup' %}
+  {% set tmp_identifier = model['alias'] + '__dbt_tmp' %}
+  {% set backup_identifier = model['alias'] + '__dbt_backup' %}
   {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}
   {% set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,

--- a/dbt/include/oracle/macros/materializations/view/view.sql
+++ b/dbt/include/oracle/macros/materializations/view/view.sql
@@ -18,7 +18,7 @@
 
   {%- set identifier = model['alias'] -%}
   {%- set grant_config = config.get('grants') -%}
-  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}
+  {%- set backup_identifier = model['alias'] + '__dbt_backup' -%}
 
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database,

--- a/dbt_adbs_test_project/models/internet_sales_channel_customers.sql
+++ b/dbt_adbs_test_project/models/internet_sales_channel_customers.sql
@@ -13,6 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 #}
+{{config(materialized='table', parallel=4, table_compression_clause='COLUMN STORE COMPRESS FOR QUERY')}}
 select c.cust_id, c.cust_first_name, c.cust_last_name, t.country_iso_code, t.country_name, t.country_region
 from {{ ref('sales_internet_channel') }} s, {{ source('sh_database', 'countries') }} t, {{ source('sh_database', 'customers') }} c
 WHERE s.cust_id = c.cust_id


### PR DESCRIPTION
- Support for specifying CTAS degree of parallelism in dbt model config -> https://github.com/oracle/dbt-oracle/issues/65
- Support for specifying table compression in dbt model config -> https://github.com/oracle/dbt-oracle/issues/65
- Fixed "Identifier too long" issue for Oracle 11; workaround is to use a shorter alias specified in dbt config