### PR TITLE
Fix for Github actions - CI pipeline

### DIFF
--- a/.github/workflows/oracle-xe-adapter-tests.yml
+++ b/.github/workflows/oracle-xe-adapter-tests.yml
@@ -51,6 +51,7 @@ jobs:
           pip install pytest dbt-tests-adapter==1.5.3
           pip install -r requirements.txt
           pip install -e .
+          pip install sqlparse==0.4.3
 
       - name: Check create-pem-from-p12 script is installed in bin
         run: |

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,7 +9,7 @@ importlib-metadata==4.11.3
 Jinja2==3.1.1
 MarkupSafe==2.1.1
 packaging==21.3
-Pygments==2.11.2
+Pygments==2.15.0
 pyparsing==3.0.8
 pytz==2022.1
 requests==2.31.0


### PR DESCRIPTION
Test case  TestSingularTestsEphemeralOracle  intermittently fails after upgrade to sqlparse=0.4.4. It only fails on Ubuntu which is used by Github Actions in our CI pipeline

Multiple adapters reported with this with dbt Labs and they are working on identifying the root cause:

 - https://github.com/dbt-labs/dbt-core/issues/8103
 - https://github.com/dbt-labs/dbt-core/issues/7396
 - https://github.com/dbt-labs/dbt-core/issues/7521
 - https://github.com/dbt-labs/dbt-core/issues/7595


Temporary workaround is to downgrade `sqlparse==0.4.3` only in our Github CI pipeline