### PR TITLE
Bugfix/110

### DIFF
--- a/dbt/adapters/oracle/connections.py
+++ b/dbt/adapters/oracle/connections.py
@@ -189,7 +189,7 @@ class OracleAdapterConnectionManager(SQLConnectionManager):
         return {
             "action": credentials.session_info.get("action", default_action),
             "client_identifier": credentials.session_info.get("client_identifier", default_client_identifier),
-            "client_info": credentials.session_info.get("client_info", default_client_info),
+            "clientinfo": credentials.session_info.get("client_info", default_client_info),
             "module": credentials.session_info.get("module", default_module)
         }
 

--- a/dbt/adapters/oracle/connections.py
+++ b/dbt/adapters/oracle/connections.py
@@ -242,7 +242,10 @@ class OracleAdapterConnectionManager(SQLConnectionManager):
             session_info = cls.get_session_info(credentials=credentials)
             logger.info(f"Session info :{json.dumps(session_info)}")
             for k, v in session_info.items():
-                setattr(handle, k, v)
+                try:
+                    setattr(handle, k, v)
+                except AttributeError:
+                    logger.warning(f"Python driver does not support setting {k}")
             connection.handle = handle
             connection.state = 'open'
         except oracledb.DatabaseError as e:

--- a/dbt_adbs_test_project/profiles.yml
+++ b/dbt_adbs_test_project/profiles.yml
@@ -12,6 +12,11 @@ dbt_test:
          #database: "{{ env_var('DBT_ORACLE_DATABASE') }}"
          schema: "{{ env_var('DBT_ORACLE_SCHEMA') }}"
          oml_cloud_service_url: "{{ env_var('DBT_ORACLE_OML_CLOUD_SERVICE_URL')}}"
+         session_info:
+           action: "dbt run"
+           client_identifier: "dbt-mac-abhisoms"
+           client_info: "dbt Python3.9 thin driver"
+           module: "dbt-module-1.5.2"
          retry_count: 1
          retry_delay: 5
          shardingkey:
@@ -42,6 +47,11 @@ dbt_test:
           database: "{{ env_var('DBT_ORACLE_DATABASE') }}"
           tns_name: "{{ env_var('DBT_ORACLE_TNS_NAME') }}"
           schema: "{{ env_var('DBT_ORACLE_SCHEMA') }}"
+          session_info:
+            action: "dbt run"
+            client_identifier: "dbt-mac-abhisoms"
+            client_info: "dbt Python3.9 thin driver"
+            module: "dbt-module-1.5.2"
           shardingkey:
               - skey
           supershardingkey:


### PR DESCRIPTION
Fixes #110 

Updated dbt profile to support `session_info` provided by user. User scan track active sessions in v$session using these values:

```yaml
 session_info:
      action: "dbt run"
      client_identifier: "abhisoms_mac"
      client_info: "x86_64"
      module: "dbt-module-1.5.2"
```