### PR TITLE
Custom `session_info`  in dbt profile

### DIFF
--- a/.github/workflows/oracle-xe-adapter-tests.yml
+++ b/.github/workflows/oracle-xe-adapter-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dbt-oracle with core dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest dbt-tests-adapter~=1.6
+          pip install pytest dbt-tests-adapter~=1.6,<1.7
           pip install -r requirements.txt
           pip install -e .
 

--- a/.github/workflows/oracle-xe-adapter-tests.yml
+++ b/.github/workflows/oracle-xe-adapter-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dbt-oracle with core dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest dbt-tests-adapter~=1.6,<1.7
+          pip install pytest 'dbt-tests-adapter~=1.6,<1.7'
           pip install -r requirements.txt
           pip install -e .
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Configuration variables
-VERSION=1.6.0
+VERSION=1.6.1
 PROJ_DIR?=$(shell pwd)
 VENV_DIR?=${PROJ_DIR}/.bldenv
 BUILD_DIR=${PROJ_DIR}/build

--- a/dbt/adapters/oracle/__version__.py
+++ b/dbt/adapters/oracle/__version__.py
@@ -14,4 +14,4 @@ Copyright (c) 2020, Vitor Avancini
   See the License for the specific language governing permissions and
   limitations under the License.
 """
-version = "1.6.0"
+version = "1.6.7"

--- a/dbt/adapters/oracle/connections.py
+++ b/dbt/adapters/oracle/connections.py
@@ -17,9 +17,11 @@ Copyright (c) 2020, Vitor Avancini
 from typing import List, Optional, Tuple, Any, Dict, Union
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+import json
 import enum
 import time
 import uuid
+import platform
 
 import dbt.exceptions
 from dbt.adapters.base import Credentials
@@ -112,6 +114,9 @@ class OracleAdapterCredentials(Credentials):
     # Base URL for ADB-S OML REST API
     oml_cloud_service_url: Optional[str] = None
 
+    # session info is stored in v$session for each dbt run
+    session_info: Optional[Dict[str, str]] = field(default_factory=dict)
+
 
     _ALIASES = {
         'dbname': 'database',
@@ -136,7 +141,8 @@ class OracleAdapterCredentials(Credentials):
             'service', 'connection_string',
             'shardingkey', 'supershardingkey',
             'cclass', 'purity', 'retry_count',
-            'retry_delay', 'oml_cloud_service_url'
+            'retry_delay', 'oml_cloud_service_url',
+            'session_info'
         )
 
     @classmethod
@@ -173,6 +179,19 @@ class OracleAdapterCredentials(Credentials):
 
 class OracleAdapterConnectionManager(SQLConnectionManager):
     TYPE = 'oracle'
+
+    @staticmethod
+    def get_session_info(credentials):
+        default_action = "DBT RUN"
+        default_client_identifier = f'dbt-oracle-client-{uuid.uuid4()}'
+        default_client_info = "_".join([platform.node(), platform.machine()])
+        default_module = f'dbt-{dbt_version}'
+        return {
+            "action": credentials.session_info.get("action", default_action),
+            "client_identifier": credentials.session_info.get("client_identifier", default_client_identifier),
+            "client_info": credentials.session_info.get("client_info", default_client_info),
+            "module": credentials.session_info.get("module", default_module)
+        }
 
     @classmethod
     def open(cls, connection):
@@ -219,8 +238,14 @@ class OracleAdapterConnectionManager(SQLConnectionManager):
         try:
             handle = oracledb.connect(**conn_config)
             # client_identifier and module are saved in corresponding columns in v$session
-            handle.module = f'dbt-{dbt_version}'
-            handle.client_identifier = f'dbt-oracle-client-{uuid.uuid4()}'
+            session_info = cls.get_session_info(credentials=credentials)
+            logger.info(f"Session info :{json.dumps(session_info)}")
+            for k, v in session_info.items():
+                try:
+                    setattr(handle, k, v)
+                except AttributeError:
+                    logger.warning(f"Python driver does not support setting {k}")
+
             connection.handle = handle
             connection.state = 'open'
         except oracledb.DatabaseError as e:

--- a/dbt/adapters/oracle/connections.py
+++ b/dbt/adapters/oracle/connections.py
@@ -189,7 +189,7 @@ class OracleAdapterConnectionManager(SQLConnectionManager):
         return {
             "action": credentials.session_info.get("action", default_action),
             "client_identifier": credentials.session_info.get("client_identifier", default_client_identifier),
-            "client_info": credentials.session_info.get("client_info", default_client_info),
+            "clientinfo": credentials.session_info.get("client_info", default_client_info),
             "module": credentials.session_info.get("module", default_module)
         }
 

--- a/dbt_adbs_test_project/profiles.yml
+++ b/dbt_adbs_test_project/profiles.yml
@@ -12,6 +12,11 @@ dbt_test:
          #database: "{{ env_var('DBT_ORACLE_DATABASE') }}"
          schema: "{{ env_var('DBT_ORACLE_SCHEMA') }}"
          oml_cloud_service_url: "{{ env_var('DBT_ORACLE_OML_CLOUD_SERVICE_URL')}}"
+         session_info:
+           action: "dbt run"
+           client_identifier: "dbt-mac-abhisoms"
+           client_info: "dbt Python3.9 thin driver"
+           module: "dbt-module-1.5.2"
          retry_count: 1
          retry_delay: 5
          shardingkey:
@@ -42,6 +47,11 @@ dbt_test:
           database: "{{ env_var('DBT_ORACLE_DATABASE') }}"
           tns_name: "{{ env_var('DBT_ORACLE_TNS_NAME') }}"
           schema: "{{ env_var('DBT_ORACLE_SCHEMA') }}"
+          session_info:
+            action: "dbt run"
+            client_identifier: "dbt-mac-abhisoms"
+            client_info: "dbt Python3.9 thin driver"
+            module: "dbt-module-1.5.2"
           shardingkey:
               - skey
           supershardingkey:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dbt-core~=1.6
+dbt-core~=1.6,<1.7
 cx_Oracle==8.3.0
-oracledb==1.4.1
+oracledb==1.4.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ tox
 coverage
 twine
 pytest
-dbt-tests-adapter~=1.6
+dbt-tests-adapter~=1.6,<1.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dbt-oracle
-version = 1.6.0
+version = 1.6.1
 description = dbt (data build tool) adapter for the Oracle database
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -32,9 +32,9 @@ zip_safe = False
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dbt-core~=1.6
+    dbt-core~=1.6,<1.7
     cx_Oracle==8.3.0
-    oracledb==1.4.1
+    oracledb==1.4.2
 test_suite=tests
 test_requires =
     dbt-tests-adapter~=1.6

--- a/setup.py
+++ b/setup.py
@@ -40,13 +40,13 @@ with open('README.md') as readme_file:
 
 
 requirements = [
-        "dbt-core~=1.6",
+        "dbt-core~=1.6,<1.7",
         "cx_Oracle==8.3.0",
-        "oracledb==1.4.1"
+        "oracledb==1.4.2"
 ]
 
 test_requirements = [
-    "dbt-tests-adapter~=1.6",
+    "dbt-tests-adapter~=1.6,<1.7",
     "pytest"
 ]
 
@@ -60,7 +60,7 @@ project_urls = {
 
 url = 'https://github.com/oracle/dbt-oracle'
 
-VERSION = '1.6.0'
+VERSION = '1.6.1'
 setup(
     author="Oracle",
     python_requires='>=3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ passenv =
 
 deps =
     -rrequirements.txt
-    dbt-tests-adapter~=1.6
+    dbt-tests-adapter~=1.6,<1.7
     pytest
 
 commands = pytest


### PR DESCRIPTION
Fixes https://github.com/oracle/dbt-oracle/issues/110

Updated dbt profile to support session_info provided by user. User scan track active sessions in `v$session` using these values:

```yaml
 session_info:
      action: "dbt run"
      client_identifier: "abhisoms_mac"
      client_info: "x86_64"
      module: "dbt-module-1.5.2"
```