### PR TITLE
bugfix to handle full refresh correctly

### DIFF
--- a/dbt/include/oracle/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/oracle/macros/materializations/incremental/incremental.sql
@@ -17,7 +17,7 @@
 {% materialization incremental, adapter='oracle', supported_languages=['sql', 'python'] %}
 
   {% set unique_key = config.get('unique_key') %}
-  {% set full_refresh_mode = flags.FULL_REFRESH %}
+  {% set full_refresh_mode = should_full_refresh() %}
   {%- set language = model['language'] -%}
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}

--- a/dbt_adbs_test_project/models/us_product_sales_channel_ranking.sql
+++ b/dbt_adbs_test_project/models/us_product_sales_channel_ranking.sql
@@ -17,6 +17,7 @@
     config(
         materialized='incremental',
         unique_key='group_id',
+        full_refresh=false,
         parallel=4,
         table_compression_clause='COLUMN STORE COMPRESS FOR QUERY LOW')
 }}


### PR DESCRIPTION
The logic to determine if full refresh is needed is encoded in the dbt-core macro `should_full_refresh()`