### PR TITLE
Updated "delete+insert" incremental strategy macros

### DIFF
--- a/dbt/adapters/oracle/__version__.py
+++ b/dbt/adapters/oracle/__version__.py
@@ -14,4 +14,4 @@ Copyright (c) 2020, Vitor Avancini
   See the License for the specific language governing permissions and
   limitations under the License.
 """
-version = "1.7.9"
+version = "1.7.10"

--- a/dbt_adbs_test_project/models/us_product_delete_insert.sql
+++ b/dbt_adbs_test_project/models/us_product_delete_insert.sql
@@ -16,6 +16,8 @@
 {{
     config(
         materialized='incremental',
+        unique_key='group_id',
+        incremental_predicates=["DBT_INTERNAL_DEST.calendar_month_desc > TO_CHAR(sysdate, ''yyyy/mm/dd'')"],
         incremental_strategy='delete+insert',
         parallel=4,
         partition_config={"clause": "PARTITION BY HASH(PROD_NAME) PARTITIONS 4"},


### PR DESCRIPTION
The delete+insert incremental strategy does the following in each incremental run

1.  Select new records using the `WHERE` clause

```sql
create global temporary table o$pt_us_product_delete_insert120225489099
on commit preserve rows
as
select {{ model_sql }}
AND times.calendar_month_desc > (SELECT MAX(calendar_month_desc) FROM dbt_test.us_product_delete_insert)
```


2. Delete existing records from destination table based on matching unique keys

```sql
DELETE FROM dbt_test.us_product_delete_insert DBT_INTERNAL_DEST
  WHERE ( DBT_INTERNAL_DEST.PROD_NAME ,  DBT_INTERNAL_DEST.GROUP_ID)
  IN    ( SELECT  DBT_INTERNAL_SOURCE.PROD_NAME , DBT_INTERNAL_SOURCE.GROUP_ID 
          FROM o$pt_us_product_delete_insert120225489099 DBT_INTERNAL_SOURCE)

```

3. Insert newly selected records

```sql
insert  /*+parallel(4)*/  into  dbt_test.us_product_delete_insert (PROD_NAME, CHANNEL_DESC, CALENDAR_MONTH_DESC, GROUP_ID, SALES$, DEFAULT_RANK, CUSTOM_RANK)
(select PROD_NAME, CHANNEL_DESC, CALENDAR_MONTH_DESC, GROUP_ID, SALES$, DEFAULT_RANK, CUSTOM_RANK
 from o$pt_us_product_delete_insert120225489099)
```