### PR TITLE
v1.7.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Configuration variables
-VERSION=1.7.4
+VERSION=1.7.5
 PROJ_DIR?=$(shell pwd)
 VENV_DIR?=${PROJ_DIR}/.bldenv
 BUILD_DIR=${PROJ_DIR}/build

--- a/dbt/adapters/oracle/__version__.py
+++ b/dbt/adapters/oracle/__version__.py
@@ -14,4 +14,4 @@ Copyright (c) 2020, Vitor Avancini
   See the License for the specific language governing permissions and
   limitations under the License.
 """
-version = "1.7.11"
+version = "1.7.13"

--- a/dbt/adapters/oracle/__version__.py
+++ b/dbt/adapters/oracle/__version__.py
@@ -14,4 +14,4 @@ Copyright (c) 2020, Vitor Avancini
   See the License for the specific language governing permissions and
   limitations under the License.
 """
-version = "1.7.13"
+version = "1.7.14"

--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -151,7 +151,7 @@
       create {% if temporary -%}
         global temporary
       {%- endif %} table {{ relation.include(schema=(not temporary)) }}
-      {%- if contract_config.enforced -%}
+      {%- if contract_config.enforced and not temporary -%}
           {{ get_assert_columns_equivalent(sql) }}
           {{ get_table_columns_and_constraints() }}
           {%- set sql = get_select_subquery(sql) %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 dbt-core~=1.7,<1.8
-oracledb==2.1.2
+oracledb==2.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dbt-oracle
-version = 1.7.4
+version = 1.7.5
 description = dbt (data build tool) adapter for Oracle Autonomous Database
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find_namespace:
 include_package_data = True
 install_requires =
     dbt-core~=1.7,<1.8
-    oracledb==2.1.2
+    oracledb==2.2.0
 test_suite=tests
 test_requires =
     dbt-tests-adapter~=1.7,<1.8

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ project_urls = {
 
 url = 'https://github.com/oracle/dbt-oracle'
 
-VERSION = '1.7.4'
+VERSION = '1.7.5'
 setup(
     author="Oracle",
     python_requires='>=3.8',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ with open('README.md') as readme_file:
 
 requirements = [
         "dbt-core~=1.7,<1.8",
-        "oracledb==2.1.2"
+        "oracledb==2.2.0"
 ]
 
 test_requirements = [


### PR DESCRIPTION
- Upgrade oracledb driver to v2.2.0
- Fix `Oracle error: ORA-14452: attempt to create, alter or drop an index on temporary table already in use` while using constraints with Incremental materialization. Issue discussed and fix verified in this slack thread : https://getdbt.slack.com/archives/C01PWH4TXLY/p1712669363630279