### PR TITLE
v1.6.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Configuration variables
-VERSION=1.6.3
+VERSION=1.6.4
 PROJ_DIR?=$(shell pwd)
 VENV_DIR?=${PROJ_DIR}/.bldenv
 BUILD_DIR=${PROJ_DIR}/build

--- a/dbt/adapters/oracle/__version__.py
+++ b/dbt/adapters/oracle/__version__.py
@@ -14,4 +14,4 @@ Copyright (c) 2020, Vitor Avancini
   See the License for the specific language governing permissions and
   limitations under the License.
 """
-version = "1.6.9"
+version = "1.6.14"

--- a/dbt/adapters/oracle/impl.py
+++ b/dbt/adapters/oracle/impl.py
@@ -329,7 +329,7 @@ class OracleAdapter(SQLAdapter):
             return column
 
     def valid_incremental_strategies(self):
-        return ["append", "merge"]
+        return ["append", "merge", "delete+insert"]
 
     @available
     @classmethod

--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -146,17 +146,19 @@
       {%- set parallel = config.get('parallel', none) -%}
       {%- set compression_clause = config.get('table_compression_clause', none) -%}
       {%- set contract_config = config.get('contract') -%}
+      {%- set partition_clause = config.get('partition_config', {}).get('clause') -%}
       {{ sql_header if sql_header is not none }}
       create {% if temporary -%}
         global temporary
       {%- endif %} table {{ relation.include(schema=(not temporary)) }}
-      {%- if contract_config.enforced -%}
+      {%- if contract_config.enforced and not temporary -%}
           {{ get_assert_columns_equivalent(sql) }}
           {{ get_table_columns_and_constraints() }}
           {%- set sql = get_select_subquery(sql) %}
       {% endif %}
       {% if temporary -%} on commit preserve rows {%- endif %}
       {% if not temporary -%}
+        {% if partition_clause %} {{ partition_clause }} {% endif %}
         {% if parallel %} parallel {{ parallel }}{% endif %}
         {% if compression_clause %} {{ compression_clause }} {% endif %}
       {%- endif %}

--- a/dbt_adbs_test_project/models/us_product_delete_insert.sql
+++ b/dbt_adbs_test_project/models/us_product_delete_insert.sql
@@ -1,5 +1,5 @@
 {#
- Copyright (c) 2022, Oracle and/or its affiliates.
+ Copyright (c) 2024, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 {{
     config(
         materialized='incremental',
-        unique_key='group_id',
-	full_refresh=false,
+        incremental_strategy='delete+insert',
         parallel=4,
         partition_config={"clause": "PARTITION BY HASH(PROD_NAME) PARTITIONS 4"},
         table_compression_clause='COLUMN STORE COMPRESS FOR QUERY LOW')
@@ -42,4 +41,3 @@ WHERE sales.prod_id=products.prod_id AND sales.cust_id=customers.cust_id
 {% endif %}
 
 GROUP BY prod_name, channel_desc, calendar_month_desc
-

--- a/dbt_adbs_test_project/profiles.yml
+++ b/dbt_adbs_test_project/profiles.yml
@@ -19,12 +19,6 @@ dbt_test:
            module: "dbt-module-1.5.2"
          retry_count: 1
          retry_delay: 5
-         shardingkey:
-           - skey
-         supershardingkey:
-           - sskey
-         cclass: CONNECTIVITY_CLASS
-         purity: self
          threads: 1
       test:
           type: oracle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 dbt-core~=1.6,<1.7
 cx_Oracle==8.3.0
-oracledb==2.0.1
+oracledb==2.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dbt-oracle
-version = 1.6.3
+version = 1.6.4
 description = dbt (data build tool) adapter for the Oracle database
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -34,7 +34,7 @@ include_package_data = True
 install_requires =
     dbt-core~=1.6,<1.7
     cx_Oracle==8.3.0
-    oracledb==2.0.1
+    oracledb==2.2.0
 test_suite=tests
 test_requires =
     dbt-tests-adapter~=1.6

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ with open('README.md') as readme_file:
 requirements = [
         "dbt-core~=1.6,<1.7",
         "cx_Oracle==8.3.0",
-        "oracledb==2.0.1"
+        "oracledb==2.2.0"
 ]
 
 test_requirements = [
@@ -60,7 +60,7 @@ project_urls = {
 
 url = 'https://github.com/oracle/dbt-oracle'
 
-VERSION = '1.6.3'
+VERSION = '1.6.4'
 setup(
     author="Oracle",
     python_requires='>=3.8',


### PR DESCRIPTION
## 1.6-backports

- Upgrade oracledb driver to v2.2.0

- Fix Oracle error: ORA-14452: attempt to create, alter or drop an index on temporary table already in use while using constraints with Incremental materialization. Issue discussed and fix verified in this slack thread : https://getdbt.slack.com/archives/C01PWH4TXLY/p1712669363630279

-  #128

- Support for new `partition_config` in table and incremental materialization
```python
partition_config={"clause": "PARTITION BY HASH(PROD_NAME) PARTITIONS 4"}
```