### PR TITLE
v1.8.0

### DIFF
--- a/.github/workflows/oracle-xe-adapter-tests.yml
+++ b/.github/workflows/oracle-xe-adapter-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dbt-oracle with core dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest 'dbt-tests-adapter~=1.7,<1.8'
+          pip install pytest 'dbt-tests-adapter~=1.8,<1.9'
           pip install -r requirements.txt
           pip install -e .
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Configuration variables
-VERSION=1.7.5
+VERSION=1.8.0
 PROJ_DIR?=$(shell pwd)
 VENV_DIR?=${PROJ_DIR}/.bldenv
 BUILD_DIR=${PROJ_DIR}/build

--- a/dbt/adapters/oracle/__init__.py
+++ b/dbt/adapters/oracle/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2024, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,6 @@ Copyright (c) 2020, Vitor Avancini
 from dbt.adapters.oracle.connections import OracleAdapterConnectionManager
 from dbt.adapters.oracle.connections import OracleAdapterCredentials
 from dbt.adapters.oracle.impl import OracleAdapter
-
 from dbt.adapters.base import AdapterPlugin
 from dbt.include import oracle
 

--- a/dbt/adapters/oracle/__version__.py
+++ b/dbt/adapters/oracle/__version__.py
@@ -14,4 +14,4 @@ Copyright (c) 2020, Vitor Avancini
   See the License for the specific language governing permissions and
   limitations under the License.
 """
-version = "1.7.14"
+version = "1.8.0"

--- a/dbt/adapters/oracle/connection_helper.py
+++ b/dbt/adapters/oracle/connection_helper.py
@@ -17,10 +17,10 @@ Copyright (c) 2020, Vitor Avancini
 import enum
 import os
 
-import dbt.exceptions
-from dbt.events import AdapterLogger
+import dbt_common.exceptions
+from dbt.adapters.events.logging import AdapterLogger
 
-from dbt.ui import warning_tag, yellow, red
+from dbt_common.ui import warning_tag, yellow, red
 
 logger = AdapterLogger("oracle")
 
@@ -129,5 +129,5 @@ elif ORA_PYTHON_DRIVER_TYPE == OracleDriverType.THIN:
     SQLNET_ORA_CONFIG = OracleNetConfig.from_env()
     logger.info("Running in thin mode")
 else:
-    raise dbt.exceptions.DbtRuntimeError("Invalid value set for ORA_PYTHON_DRIVER_TYPE\n"
-                                         "Use any one of 'cx', 'thin', or 'thick'")
+    raise dbt_common.exceptions.DbtRuntimeError("Invalid value set for ORA_PYTHON_DRIVER_TYPE\n"
+                                                "Use any one of 'cx', 'thin', or 'thick'")

--- a/dbt/adapters/oracle/connection_helper.py
+++ b/dbt/adapters/oracle/connection_helper.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2024, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/dbt/adapters/oracle/impl.py
+++ b/dbt/adapters/oracle/impl.py
@@ -84,10 +84,10 @@ LIST_RELATIONS_MACRO_NAME = 'list_relations_without_caching'
 GET_DATABASE_MACRO_NAME = 'get_database_name'
 
 MISSING_DATABASE_NAME_FOR_CATALOG_WARNING_MESSAGE = (
-    "database key is missing from the target-profile in the file profiles.yml "
+    "database key is missing from the target profile in the file profiles.yml "
     "\n Starting with dbt-oracle 1.8  database name is needed for catalog generation "
     "\n Without database key in the target profile the generated catalog will be empty "
-    "\n \t i.e. `dbt docs generate` command will generate an empty catalog json "
+    "\n i.e. `dbt docs generate` command will generate an empty catalog json "
     "\n Make the following entry in dbt profile.yml file for the target profile "
     "\n database: {0}"
 )

--- a/dbt/adapters/oracle/python_submissions.py
+++ b/dbt/adapters/oracle/python_submissions.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2024, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ import platform
 import requests
 import time
 
-import dbt.exceptions
+import dbt_common.exceptions
 from dbt.adapters.oracle import OracleAdapterCredentials
-from dbt.events import AdapterLogger
-from dbt.ui import red, green
+from dbt.adapters.events.logging import AdapterLogger
+from dbt_common.ui import red, green
 from dbt.version import __version__ as dbt_version
 
 # ADB-S OML Rest API minimum timeout is 1800 seconds
@@ -170,7 +170,7 @@ class OracleADBSPythonJob:
             r.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(red(f"Error {e} scheduling async Python job for model {self.identifier}"))
-            raise dbt.exceptions.DbtRuntimeError(f"Error scheduling Python model {self.identifier}")
+            raise dbt_common.exceptions.DbtRuntimeError(f"Error scheduling Python model {self.identifier}")
 
         job_location = r.headers["location"]
         logger.info(f"Started async job {job_location}")
@@ -192,24 +192,24 @@ class OracleADBSPythonJob:
                     job_result_json = job_result.json()
                     if 'errorMessage' in job_result_json:
                         logger.error(red(f"FAILURE - Python model {self.identifier} Job failure is: {job_result_json}"))
-                        raise dbt.exceptions.DbtRuntimeError(f"Error running Python model {self.identifier}")
+                        raise dbt_common.exceptions.DbtRuntimeError(f"Error running Python model {self.identifier}")
                     job_result.raise_for_status()
                     logger.info(green(f"SUCCESS - Python model {self.identifier} Job result is: {job_result_json}"))
                     return
                 elif job_status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR:
                     logger.error(red(f"FAILURE - Job status is: {job_status.json()}"))
-                    raise dbt.exceptions.DbtRuntimeError(f"Error running Python model {self.identifier}")
+                    raise dbt_common.exceptions.DbtRuntimeError(f"Error running Python model {self.identifier}")
                 else:
                     logger.debug(f"Python model {self.identifier} job status is: {job_status.json()}")
                     job_status.raise_for_status()
 
             except requests.exceptions.RequestException as e:
                 logger.error(red(f"Error {e} checking status of Python job {job_location}  for model {self.identifier}"))
-                raise dbt.exceptions.DbtRuntimeError(f"Error checking status for job {job_location}")
+                raise dbt_common.exceptions.DbtRuntimeError(f"Error checking status for job {job_location}")
 
             time.sleep(DEFAULT_DELAY_BETWEEN_POLL_IN_SECONDS)
         logger.error(red(f"Timeout error for Python model {self.identifier}"))
-        raise dbt.exceptions.DbtRuntimeError(f"Timeout error for Python model {self.identifier}")
+        raise dbt_common.exceptions.DbtRuntimeError(f"Timeout error for Python model {self.identifier}")
 
     def __call__(self, *args, **kwargs):
         data = {
@@ -234,10 +234,10 @@ class OracleADBSPythonJob:
                 job_result = r.json()
                 if 'errorMessage' in job_result:
                     logger.error(red(f"FAILURE - Python model {self.identifier} Job failure is: {job_result}"))
-                    raise dbt.exceptions.DbtRuntimeError(f"Error running Python model {self.identifier}")
+                    raise dbt_common.exceptions.DbtRuntimeError(f"Error running Python model {self.identifier}")
                 r.raise_for_status()
                 logger.info(green(f"SUCCESS - Python model {self.identifier} Job result is: {job_result}"))
             except requests.exceptions.RequestException as e:
                 logger.error(red(f"Error {e} running Python model {self.identifier}"))
-                raise dbt.exceptions.DbtRuntimeError(f"Error running Python model {self.identifier}")
+                raise dbt_common.exceptions.DbtRuntimeError(f"Error running Python model {self.identifier}")
 

--- a/dbt/adapters/oracle/relation.py
+++ b/dbt/adapters/oracle/relation.py
@@ -19,6 +19,7 @@ from typing import Optional
 from dataclasses import dataclass, field
 
 from dbt.adapters.base.relation import BaseRelation
+from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.relation_configs import (
     RelationConfigBase,
     RelationConfigChangeAction,
@@ -26,7 +27,7 @@ from dbt.adapters.relation_configs import (
 )
 from dbt.context.providers import RuntimeConfigObject
 from dbt.contracts.graph.nodes import ModelNode
-from dbt.contracts.relation import RelationType
+from dbt.adapters.base import RelationType
 from dbt.exceptions import DbtRuntimeError
 
 from dbt.adapters.oracle.relation_configs import (
@@ -40,7 +41,7 @@ from dbt.adapters.oracle.relation_configs import (
     OracleQuotePolicy,
     OracleIncludePolicy)
 
-from dbt.events import AdapterLogger
+
 
 logger = AdapterLogger("oracle")
 

--- a/dbt/adapters/oracle/relation_configs/base.py
+++ b/dbt/adapters/oracle/relation_configs/base.py
@@ -24,7 +24,7 @@ from dbt.adapters.relation_configs import (
     RelationResults,
 )
 from dbt.contracts.graph.nodes import ModelNode
-from dbt.contracts.relation import ComponentName
+from dbt.adapters.contracts.relation import ComponentName
 
 from dbt.adapters.oracle.relation_configs.policies import (
     OracleQuotePolicy,

--- a/dbt/adapters/oracle/relation_configs/materialized_view.py
+++ b/dbt/adapters/oracle/relation_configs/materialized_view.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2024, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,19 +15,19 @@ Copyright (c) 2023, Oracle and/or its affiliates.
 """
 
 from dataclasses import dataclass
-from typing import Optional, Set
+from typing import Optional
 
 import agate
 from dbt.adapters.oracle.relation_configs.base import OracleRelationConfigBase
 from dbt.adapters.relation_configs import RelationResults, RelationConfigChange
 
-from dbt.contracts.relation import ComponentName
+from dbt.adapters.contracts.relation import ComponentName
 
 from dbt.contracts.graph.nodes import ModelNode
-from dbt.exceptions import DbtRuntimeError
-from dbt.events import AdapterLogger
+from dbt.adapters.events.logging import AdapterLogger
 
 logger = AdapterLogger("oracle")
+
 
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
 class OracleMaterializedViewConfig(OracleRelationConfigBase):
@@ -143,6 +143,7 @@ class OracleRefreshMethodConfigChange(RelationConfigChange):
     def requires_full_refresh(self) -> bool:
         return True
 
+
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
 class OracleBuildModeConfigChange(RelationConfigChange):
     context: Optional[str] = None
@@ -151,6 +152,7 @@ class OracleBuildModeConfigChange(RelationConfigChange):
     def requires_full_refresh(self) -> bool:
         return False
 
+
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
 class OracleQueryRewriteConfigChange(RelationConfigChange):
     context: Optional[str] = None
@@ -158,6 +160,7 @@ class OracleQueryRewriteConfigChange(RelationConfigChange):
     @property
     def requires_full_refresh(self) -> bool:
         return False
+
 
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
 class OracleQueryConfigChange(RelationConfigChange):

--- a/dbt/adapters/oracle/relation_configs/policies.py
+++ b/dbt/adapters/oracle/relation_configs/policies.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2024, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ Copyright (c) 2023, Oracle and/or its affiliates.
 from dataclasses import dataclass
 
 from dbt.adapters.base.relation import Policy
-from dbt.dataclass_schema import StrEnum
+from dbt_common.dataclass_schema import StrEnum
 
 
 @dataclass

--- a/dbt/include/oracle/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/oracle/macros/materializations/incremental/strategies.sql
@@ -193,7 +193,7 @@
            from {{ temp_relation }})';
         END;
     {%- else -%}
-    insert {%- if parallel -%} /*+parallel({{ parallel }})*/ {%- endif -%} into  {{ target_relation }} ({{ dest_cols_csv }})
+    insert {% if parallel %} /*+parallel({{ parallel }})*/ {% endif %} into  {{ target_relation }} ({{ dest_cols_csv }})
     (
        select {{ dest_cols_csv }}
        from {{ temp_relation }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-dbt-core~=1.7,<1.8
-oracledb==2.2.0
+dbt-common>=1.1.0,<2.0
+dbt-adapters>=1.2.1,<2.0
+dbt-core>=1.8.1,<2.0
+oracledb==2.2.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ tox
 coverage
 twine
 pytest
-dbt-tests-adapter~=1.7,<1.8
+dbt-tests-adapter~=1.8,<1.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dbt-oracle
-version = 1.7.5
+version = 1.8.0
 description = dbt (data build tool) adapter for Oracle Autonomous Database
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -33,11 +33,13 @@ zip_safe = False
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dbt-core~=1.7,<1.8
-    oracledb==2.2.0
+    dbt-common>=1.1.0,<2.0
+    dbt-adapters>=1.2.1,<2.0
+    dbt-core~=1.8,<1.9
+    oracledb==2.2.1
 test_suite=tests
 test_requires =
-    dbt-tests-adapter~=1.7,<1.8
+    dbt-tests-adapter~=1.8,<1.9
     pytest
 scripts =
     bin/create-pem-from-p12

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,14 @@ with open('README.md') as readme_file:
 
 
 requirements = [
-        "dbt-core~=1.7,<1.8",
-        "oracledb==2.2.0"
+        "dbt-common>=1.1.0,<2.0",
+        "dbt-adapters>=1.2.1,<2.0",
+        "dbt-core~=1.8,<1.9",
+        "oracledb==2.2.1"
 ]
 
 test_requirements = [
-    "dbt-tests-adapter~=1.7,<1.8",
+    "dbt-tests-adapter~=1.8,<1.9",
     "pytest"
 ]
 
@@ -59,7 +61,7 @@ project_urls = {
 
 url = 'https://github.com/oracle/dbt-oracle'
 
-VERSION = '1.7.5'
+VERSION = '1.8.0'
 setup(
     author="Oracle",
     python_requires='>=3.8',


### PR DESCRIPTION
Addresses #138 

Decouple dbt-core and the base adapter and use a stable adapter interface i.e. `dbt-adapters`

![dbt_1 8](https://github.com/oracle/dbt-oracle/assets/14945417/fd385e8e-fcfc-463e-88ab-cd55c145ca60)


`database` key in profile.yml is still optional for all but one of the dbt-oracle workflows.  Without `database` name in profile.yml the generated catalog used for project documentation will be empty. 

Prior dbt 1.8, we could inject `database` name in the manifest because of only dependency on `dbt-core`. From dbt-oracle 1.8, the adapter can use only the stable interface i.e. `dbt-adapters`. Catalog generation task is implemented in `dbt-core` and it seems difficult to inject `database` at runtime. There is no way to override a function in `dbt-core`. Adapters should not in any way refer to `dbt-core`. 

For now, to circumvent the problem, I detect that `database` key is missing from profile.yml and issue a warning message to the user to add an entry in profile.yml for catalog generation The warning message also shows the database name that dbt-oracle expects. That way users don't have to worry about "what" the `database` name is and "how" to get it. 


