### PR TITLE
1.7 backports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Configuration variables
-VERSION=1.7.6
+VERSION=1.7.7
 PROJ_DIR?=$(shell pwd)
 VENV_DIR?=${PROJ_DIR}/.bldenv
 BUILD_DIR=${PROJ_DIR}/build

--- a/dbt/adapters/oracle/__version__.py
+++ b/dbt/adapters/oracle/__version__.py
@@ -14,4 +14,4 @@ Copyright (c) 2020, Vitor Avancini
   See the License for the specific language governing permissions and
   limitations under the License.
 """
-version = "1.7.16"
+version = "1.7.17"

--- a/dbt/include/oracle/macros/adapters.sql
+++ b/dbt/include/oracle/macros/adapters.sql
@@ -260,8 +260,12 @@
 
 {% macro oracle__alter_relation_comment(relation, comment) %}
   {% set escaped_comment = oracle_escape_comment(comment) %}
+  {% if relation.type == 'materialized_view' %}
+  comment on materialized view {{ relation }} is {{ escaped_comment }}
+  {% else %}
   {# "comment on table" even for views #}
   comment on table {{ relation }} is {{ escaped_comment }}
+  {% endif %}
 {% endmacro %}
 
 {% macro oracle__persist_docs(relation, model, for_relation, for_columns) -%}

--- a/dbt_adbs_test_project/models/sales_internet_mv.sql
+++ b/dbt_adbs_test_project/models/sales_internet_mv.sql
@@ -13,6 +13,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 #}
-{{ config(materialized='materialized_view')}}
+{{ config(materialized='materialized_view',  persist_docs={"relation": true, "columns": true}) }}
 select * from {{ source('sh_database', 'sales') }}
 where channel_id = 5

--- a/dbt_adbs_test_project/models/schema.yml
+++ b/dbt_adbs_test_project/models/schema.yml
@@ -22,6 +22,9 @@ sources:
       - name: costs
 
 models:
+  - name: sales_internet_mv
+    description: Test comment for Materialized View
+
   - name: kafka
     description: kafka_description
     config:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dbt-oracle
-version = 1.7.6
+version = 1.7.7
 description = dbt (data build tool) adapter for Oracle Autonomous Database
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ project_urls = {
 
 url = 'https://github.com/oracle/dbt-oracle'
 
-VERSION = '1.7.6'
+VERSION = '1.7.7'
 setup(
     author="Oracle",
     python_requires='>=3.8',


### PR DESCRIPTION
- Bumped dbt-oracle version to 1.7.7
- Fixes `oracle adapter: Oracle error: ORA-12098: cannot comment on the materialized view`