### PR TITLE
Fix incremental models failing with ORA-00955 by ignoring database parameter in get_relation()

### DIFF
--- a/dbt/adapters/oracle/impl.py
+++ b/dbt/adapters/oracle/impl.py
@@ -212,9 +212,10 @@ class OracleAdapter(SQLAdapter):
         return f"{add_to} + interval '{number}' {interval}"
 
     def get_relation(self, database: str, schema: str, identifier: str) -> Optional[BaseRelation]:
-        if database == 'None':
-            database = self.config.credentials.database
-        return super().get_relation(database, schema, identifier)
+        # In Oracle the database parameter doesn't apply to relation lookups,
+        # it uses SCHEMA.TABLE, not DATABASE.SCHEMA.TABLE
+        # Use None for consistent cache lookups regardless of database parameter in profiles.yml.
+        return super().get_relation(None, schema, identifier)
 
     def _get_one_catalog_by_relations(
             self,


### PR DESCRIPTION
## Description
Fixes #193 - Incremental models now work correctly regardless of the `database` parameter value in `profiles.yml`.

## Problem
Incremental models failed on the second run with `ORA-00955: name is already used by an existing object` when the `database` parameter didn't match the Oracle `service` parameter. 

## Solution
Modified `get_relation()` in `dbt/adapters/oracle/impl.py` to always pass `None` as the database parameter to the parent method