### PR TITLE
v1.12.0

### DIFF
--- a/.github/scripts/create_new_user.sh
+++ b/.github/scripts/create_new_user.sh
@@ -4,24 +4,14 @@ set -Exeuo pipefail
 
 # Parameters
 DB_USER="${1}"
-DB_PASSWORD="${2}"
-TARGET_PDB="${3:-FREEPDB1}"
+ADMIN_PASSWORD="${2}"
+DB_PASSWORD="${3}"
 
-# Prepare container switch statement to create user in PDB.
-ALTER_SESSION_CMD="ALTER SESSION SET CONTAINER=${TARGET_PDB};"
-
-# 11g XE does not support PDBs, set container switch statement to empty string.
-ORACLE_VERSION=$(sqlplus -version | grep "Release" | awk '{ print $3 }')
-if [[ "${ORACLE_VERSION}" = "11.2"* ]]; then
-   ALTER_SESSION_CMD="";
-fi;
-
-# Create new user in target PDB
-sqlplus -s / as sysdba << EOF
+# Create the user through the ADB administrator account.
+sqlplus -s "admin/${ADMIN_PASSWORD}@localhost:1521/myatp" << EOF
    -- Exit on any errors
    WHENEVER SQLERROR EXIT SQL.SQLCODE
-   ${ALTER_SESSION_CMD}
-   CREATE USER ${DB_USER} IDENTIFIED BY "${DB_PASSWORD}" QUOTA UNLIMITED ON SYSTEM;
-   GRANT DB_DEVELOPER_ROLE TO ${DB_USER};
+   CREATE USER ${DB_USER} IDENTIFIED BY "${DB_PASSWORD}" QUOTA UNLIMITED ON DATA;
+   GRANT CONNECT, CONSOLE_DEVELOPER, DWROLE, RESOURCE TO ${DB_USER};
    exit;
 EOF

--- a/.github/scripts/install_oracle_instantclient.sh
+++ b/.github/scripts/install_oracle_instantclient.sh
@@ -1,11 +1,10 @@
 sudo apt-get update
 sudo apt-get install wget libaio1t64
 sudo mkdir -p /opt/oracle
-wget https://download.oracle.com/otn_software/linux/instantclient/2370000/instantclient-basiclite-linux.x64-23.7.0.25.01.zip -P /tmp
-sudo unzip /tmp/instantclient-basiclite-linux.x64-23.7.0.25.01.zip -d /opt/oracle
-export PATH="$PATH:/opt/oracle/instantclient_23_7"
-export LD_LIBRARY_PATH="/opt/oracle/instantclient_23_7:$LD_LIBRARY_PATH"
+wget https://download.oracle.com/otn_software/linux/instantclient/2326300/instantclient-basiclite-linux.x64-23.26.3.0.0.zip -P /tmp
+sudo unzip /tmp/instantclient-basiclite-linux.x64-23.26.3.0.0.zip -d /opt/oracle
+export PATH="$PATH:/opt/oracle/instantclient_23_26"
+export LD_LIBRARY_PATH="/opt/oracle/instantclient_23_26:$LD_LIBRARY_PATH"
 sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
 sudo mkdir -p /opt/tns_admin
 echo "DISABLE_OOB=ON" >> /opt/tns_admin/sqlnet.ora
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     services:
       oracle_db:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,8 @@
 name: dbt-tests-adapter
 on:
   push:
+    branches:
+      - "**"
   workflow_call:
 
 permissions:
@@ -62,10 +64,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[test]'
-
-      - name: Check create-pem-from-p12 script is installed in bin
-        run: |
-          create-pem-from-p12 --help
 
       - name: Run adapter tests - ORA_PYTHON_DRIVER_TYPE => THICK
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,20 +16,27 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     services:
-      oracle_db:
-        image: container-registry.oracle.com/database/free:latest-lite
+      adb:
+        image: ghcr.io/oracle/adb-free:latest-26ai
         env:
-          ORACLE_PWD: ${{ secrets.DBT_ORACLE_PASSWORD }}
-        options: --name oracle_db
+          WORKLOAD_TYPE: ATP
+          START_ORDS: "False"
+          ENABLE_ARCHIVE_LOG: "False"
+          ADMIN_PASSWORD: ${{ secrets.DBT_ORACLE_ADMIN_PASSWORD }}
+          WALLET_PASSWORD: ${{ secrets.DBT_ORACLE_TEST_WALLET_PASSWORD }}
         ports:
           - 1521:1521
+        options: >-
+          --name adb
+          --cap-add SYS_ADMIN
+          --device /dev/fuse
 
     steps:
       - name: Check out dbt-oracle repository code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -38,17 +45,18 @@ jobs:
           chmod +x ${{ github.workspace }}/.github/scripts/install_oracle_instantclient.sh
           ${{ github.workspace }}/.github/scripts/install_oracle_instantclient.sh
 
-      - name: Copy Create User script
-        run: |
-          chmod +x ${{ github.workspace }}/.github/scripts/create_new_user.sh
-          docker cp ${{ github.workspace }}/.github/scripts/create_new_user.sh oracle_db:/home/oracle/create_new_user.sh
-
       - name: Create dbt test users
         run: |
-          docker exec oracle_db /home/oracle/create_new_user.sh dbt_test ${{ secrets.DBT_ORACLE_PASSWORD }}
-          docker exec oracle_db /home/oracle/create_new_user.sh dbt_test_user_1 ${{ secrets.DBT_ORACLE_PASSWORD }}
-          docker exec oracle_db /home/oracle/create_new_user.sh dbt_test_user_2 ${{ secrets.DBT_ORACLE_PASSWORD }}
-          docker exec oracle_db /home/oracle/create_new_user.sh dbt_test_user_3 ${{ secrets.DBT_ORACLE_PASSWORD }}
+          chmod +x ${{ github.workspace }}/.github/scripts/create_new_user.sh
+          docker cp ${{ github.workspace }}/.github/scripts/create_new_user.sh adb:/tmp/create_new_user.sh
+          docker exec adb /tmp/create_new_user.sh dbt_test \
+            '${{ secrets.DBT_ORACLE_ADMIN_PASSWORD }}' '${{ secrets.DBT_ORACLE_PASSWORD }}'
+          docker exec adb /tmp/create_new_user.sh dbt_test_user_1 \
+            '${{ secrets.DBT_ORACLE_ADMIN_PASSWORD }}' '${{ secrets.DBT_ORACLE_PASSWORD }}'
+          docker exec adb /tmp/create_new_user.sh dbt_test_user_2 \
+            '${{ secrets.DBT_ORACLE_ADMIN_PASSWORD }}' '${{ secrets.DBT_ORACLE_PASSWORD }}'
+          docker exec adb /tmp/create_new_user.sh dbt_test_user_3 \
+            '${{ secrets.DBT_ORACLE_ADMIN_PASSWORD }}' '${{ secrets.DBT_ORACLE_PASSWORD }}'
 
       - name: Install dbt-oracle with core dependencies
         run: |
@@ -69,10 +77,10 @@ jobs:
           DBT_ORACLE_PORT: 1521
           DBT_ORACLE_SCHEMA: DBT_TEST
           DBT_ORACLE_PASSWORD: ${{ secrets.DBT_ORACLE_PASSWORD }}
-          DBT_ORACLE_DATABASE: FREEPDB1
-          DBT_ORACLE_SERVICE: FREEPDB1
+          DBT_ORACLE_DATABASE: MYATP
+          DBT_ORACLE_SERVICE: MYATP
           DBT_ORACLE_PROTOCOL: tcp
-          LD_LIBRARY_PATH: /opt/oracle/instantclient_23_7
+          LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
           TNS_ADMIN: /opt/tns_admin
           DBT_TEST_USER_1: DBT_TEST_USER_1
           DBT_TEST_USER_2: DBT_TEST_USER_2
@@ -88,8 +96,8 @@ jobs:
           DBT_ORACLE_PORT: 1521
           DBT_ORACLE_SCHEMA: DBT_TEST
           DBT_ORACLE_PASSWORD: ${{ secrets.DBT_ORACLE_PASSWORD }}
-          DBT_ORACLE_DATABASE: FREEPDB1
-          DBT_ORACLE_SERVICE: FREEPDB1
+          DBT_ORACLE_DATABASE: MYATP
+          DBT_ORACLE_SERVICE: MYATP
           DBT_ORACLE_PROTOCOL: tcp
           DISABLE_OOB: on
           TNS_ADMIN: /opt/tns_admin

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Configuration variables
-VERSION=1.11.1
+VERSION=1.12.0
 PROJ_DIR?=$(shell pwd)
 VENV_DIR?=${PROJ_DIR}/.bldenv
 BUILD_DIR=${PROJ_DIR}/build

--- a/dbt/adapters/oracle/__version__.py
+++ b/dbt/adapters/oracle/__version__.py
@@ -14,4 +14,4 @@ Copyright (c) 2020, Vitor Avancini
   See the License for the specific language governing permissions and
   limitations under the License.
 """
-version = "1.11.1"
+version = "1.12.0"

--- a/dbt_adbs_test_project/README.md
+++ b/dbt_adbs_test_project/README.md
@@ -21,8 +21,8 @@ dbt --version
 
 ```text
 Core:
-  - installed: 1.3.0
-  - latest:    1.3.0 - Up to date!
+  - installed: 1.12.0
+  - latest:    1.12.0 - Up to date!
 ```
 
 ### Check database connectivity
@@ -32,7 +32,7 @@ dbt debug --profiles-dir ./
 ```
 
 ```text
-dbt version: 1.3.0
+dbt version: 1.12.0
 python version: 3.8.13
 ..
 ..
@@ -65,11 +65,26 @@ After this, you can test various dbt features included in this project
 | Generic Test - Accepted values | `dbt test` | [schema.yml](./models/schema.yml)
 | Generic Test - Relationships | `dbt test` | [schema.yml](./models/schema.yml)
 | Operations |  `dbt run-operation`  | Check [macros](macros)
+| v1.12 ad hoc operation | `dbt run-operation --sql "select 1 from dual"` | Executes an Oracle statement without a macro |
+| v1.12 named selector composition | `dbt ls --select selector:sample_models` | [selectors.yml](selectors.yml) |
+| v1.12 downstream failure behavior | `dbt run -s sales_cost_incremental+` | `on_error: continue` in [properties.yml](models/properties.yml) |
 | Snapshots | `dbt snapshot` | Check [snapshots](snapshots)
 | Analyses | `dbt compile` | [eu_customers.sql](./analysis/eu_customers.sql)
 | Exposures | `dbt run` or `dbt test` | [exposures.yml](./models/exposures.yml)
 | Generate documentation | `dbt docs generate` |
 | Serve project documentation on port 8080 | `dbt docs serve`
+
+## dbt Core v1.12 compatibility
+
+The project uses the v1.12 generic-test `arguments` syntax and validates the
+new `run-operation --sql`, `selector:` selection method, and `on_error` model
+configuration. The opt-in v2 parser is not currently usable with `dbt-oracle`:
+the bundled experimental parser does not yet recognize the Oracle adapter.
+
+`dbt_constraints` 1.0.9 is the latest supported package release, but its
+published macro documentation does not match its macro signatures. With dbt
+1.12's default macro-argument validation enabled, dbt therefore emits warnings
+for that dependency. They are not caused by this project's macros or schema.
 
 
 ## Tests [TODO]

--- a/dbt_adbs_test_project/models/properties.yml
+++ b/dbt_adbs_test_project/models/properties.yml
@@ -3,3 +3,5 @@ models:
   - name: sales_cost_incremental
     config:
       post-hook: "SELECT COUNT(*) FROM sales_cost_incremental"
+      # dbt Core v1.12: allow unrelated downstream branches to continue after a failure.
+      on_error: continue

--- a/dbt_adbs_test_project/models/schema.yml
+++ b/dbt_adbs_test_project/models/schema.yml
@@ -60,7 +60,8 @@ models:
       - name: gender
         tests:
           - accepted_values:
-              values: ['Male', 'Female']
+              arguments:
+                values: ['Male', 'Female']
   - name: countries
     columns:
       - name: country_id
@@ -73,10 +74,10 @@ models:
       - name: country_id
         tests:
           - relationships:
-              to: ref('countries')
-              field: country_id
+              arguments:
+                to: ref('countries')
+                field: country_id
           - dbt_constraints.foreign_key:
-              pk_table_name: ref('countries')
-              pk_column_name: country_id
-
-
+              arguments:
+                pk_table_name: ref('countries')
+                pk_column_name: country_id

--- a/dbt_adbs_test_project/package-lock.yml
+++ b/dbt_adbs_test_project/package-lock.yml
@@ -1,6 +1,8 @@
 packages:
-- package: dbt-labs/dbt_utils
-  version: 0.8.6
-- package: Snowflake-Labs/dbt_constraints
-  version: 0.4.2
-sha1_hash: 7664cb2e33183f39e86a72079d63607e43a50ad8
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.4.1
+  - name: dbt_constraints
+    package: Snowflake-Labs/dbt_constraints
+    version: 1.0.9
+sha1_hash: b9f858fcf43fd74717c56899e55ceaf1c1789d10

--- a/dbt_adbs_test_project/packages.yml
+++ b/dbt_adbs_test_project/packages.yml
@@ -1,5 +1,5 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.8.6
+    version: 1.4.1
   - package: Snowflake-Labs/dbt_constraints
-    version: [">=0.4.0", "<0.5.0"]
+    version: 1.0.9

--- a/dbt_adbs_test_project/selectors.yml
+++ b/dbt_adbs_test_project/selectors.yml
@@ -1,0 +1,9 @@
+selectors:
+  - name: sample_models
+    description: Core sample models used for exercising the v1.12 selector method.
+    definition:
+      union:
+        - method: fqn
+          value: dbt_adbs_test_project.people
+        - method: fqn
+          value: dbt_adbs_test_project.eu.countries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbt-oracle"
-version = "1.11.1"
+version = "1.12.0"
 description = "dbt (data build tool) adapter for Oracle Autonomous Database"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
@@ -22,17 +22,18 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "dbt-common>=1.1.0,<2.0",
     "dbt-adapters>=1.2.1,<2.0",
-    "dbt-core~=1.11,<1.12",
+    "dbt-core~=1.12,<1.13",
     "oracledb",
 ]
 
 [project.optional-dependencies]
 test = [
-    "dbt-tests-adapter~=1.11,<1.12",
+    "dbt-tests-adapter",
     "pytest",
 ]
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ tox
 coverage
 twine
 pytest
-dbt-tests-adapter~=1.11,<1.12
+dbt-tests-adapter

--- a/tests/functional/adapter/constraints/test_constraints.py
+++ b/tests/functional/adapter/constraints/test_constraints.py
@@ -80,6 +80,7 @@ class OracleColumnsEqualSetup:
 class TestOracleTableConstraintsColumnsEqual(OracleColumnsEqualSetup, BaseTableConstraintsColumnsEqual):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model_wrong_order.sql": my_model_wrong_order_sql,
@@ -91,6 +92,7 @@ class TestOracleTableConstraintsColumnsEqual(OracleColumnsEqualSetup, BaseTableC
 class TestOracleViewConstraintsColumnsEqual(OracleColumnsEqualSetup, BaseViewConstraintsColumnsEqual):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model_wrong_order.sql": my_model_view_wrong_order_sql,
@@ -102,6 +104,7 @@ class TestOracleViewConstraintsColumnsEqual(OracleColumnsEqualSetup, BaseViewCon
 class TestOracleIncrementalConstraintsColumnsEqual(OracleColumnsEqualSetup, BaseIncrementalConstraintsColumnsEqual):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model_wrong_order.sql": my_model_incremental_wrong_order_sql,
@@ -113,6 +116,7 @@ class TestOracleIncrementalConstraintsColumnsEqual(OracleColumnsEqualSetup, Base
 class TestOracleTableConstraintsDdlEnforcement(BaseConstraintsRuntimeDdlEnforcement):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model.sql": my_model_wrong_order_sql,
@@ -120,6 +124,7 @@ class TestOracleTableConstraintsDdlEnforcement(BaseConstraintsRuntimeDdlEnforcem
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def expected_sql(self):
         return _expected_sql_oracle
 
@@ -127,6 +132,7 @@ class TestOracleTableConstraintsDdlEnforcement(BaseConstraintsRuntimeDdlEnforcem
 class TestOracleIncrementalConstraintsDdlEnforcement(BaseIncrementalConstraintsRuntimeDdlEnforcement):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model.sql": my_model_incremental_wrong_order_sql,
@@ -134,6 +140,7 @@ class TestOracleIncrementalConstraintsDdlEnforcement(BaseIncrementalConstraintsR
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def expected_sql(self):
         return _expected_sql_oracle
 
@@ -141,6 +148,7 @@ class TestOracleIncrementalConstraintsDdlEnforcement(BaseIncrementalConstraintsR
 class TestOracleTableConstraintsRollback(BaseConstraintsRollback):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model.sql": my_model_sql,
@@ -148,10 +156,12 @@ class TestOracleTableConstraintsRollback(BaseConstraintsRollback):
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def null_model_sql(self):
         return my_model_with_nulls_sql
 
     @pytest.fixture(scope="class")
+    @classmethod
     def expected_error_messages(self):
         return ["ORA-01400: cannot insert NULL into"]
 
@@ -159,6 +169,7 @@ class TestOracleTableConstraintsRollback(BaseConstraintsRollback):
 class TestOracleIncrementalConstraintsRollback(BaseIncrementalConstraintsRollback):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model.sql": my_incremental_model_sql,
@@ -166,10 +177,12 @@ class TestOracleIncrementalConstraintsRollback(BaseIncrementalConstraintsRollbac
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def null_model_sql(self):
         return my_model_incremental_with_nulls_sql
 
     @pytest.fixture(scope="class")
+    @classmethod
     def expected_error_messages(self):
         return ["ORA-01400: cannot insert NULL into"]
 
@@ -177,6 +190,7 @@ class TestOracleIncrementalConstraintsRollback(BaseIncrementalConstraintsRollbac
 class TestOracleModelConstraintsRuntimeEnforcement(BaseModelConstraintsRuntimeEnforcement):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model.sql": my_model_sql,
@@ -184,6 +198,7 @@ class TestOracleModelConstraintsRuntimeEnforcement(BaseModelConstraintsRuntimeEn
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def expected_sql(self):
         return """
 create table <model_identifier> (

--- a/tests/functional/adapter/constraints/test_constraints.py
+++ b/tests/functional/adapter/constraints/test_constraints.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tests/functional/adapter/incremental_materialization/quotes/test_quote_special_characters_and_keywords.py
+++ b/tests/functional/adapter/incremental_materialization/quotes/test_quote_special_characters_and_keywords.py
@@ -56,6 +56,7 @@ SELECT * FROM dual
 class TestIncrementalMergeQuoteWithKeywordsandSpecialChars:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
@@ -63,6 +64,7 @@ class TestIncrementalMergeQuoteWithKeywordsandSpecialChars:
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_incr_model.sql": my_incr_model_sql,
@@ -136,5 +138,4 @@ class TestIncrementalMergeQuoteWithKeywordsandSpecialChars:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-
 

--- a/tests/functional/adapter/incremental_materialization/quotes/test_quote_special_characters_and_keywords.py
+++ b/tests/functional/adapter/incremental_materialization/quotes/test_quote_special_characters_and_keywords.py
@@ -138,4 +138,3 @@ class TestIncrementalMergeQuoteWithKeywordsandSpecialChars:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-

--- a/tests/functional/adapter/incremental_materialization/quotes/test_quote_special_characters_and_keywords.py
+++ b/tests/functional/adapter/incremental_materialization/quotes/test_quote_special_characters_and_keywords.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/incremental_materialization/quotes/test_quoted_columns_incremental_insert.py
+++ b/tests/functional/adapter/incremental_materialization/quotes/test_quoted_columns_incremental_insert.py
@@ -131,4 +131,3 @@ class TestIncrementalInsertQuotedColumnsAllCols:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-

--- a/tests/functional/adapter/incremental_materialization/quotes/test_quoted_columns_incremental_insert.py
+++ b/tests/functional/adapter/incremental_materialization/quotes/test_quoted_columns_incremental_insert.py
@@ -55,6 +55,7 @@ SELECT * FROM dual
 class TestIncrementalInsertQuotedColumnsAllCols:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
@@ -62,6 +63,7 @@ class TestIncrementalInsertQuotedColumnsAllCols:
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_incr_model.sql": my_incr_model_sql,
@@ -129,5 +131,4 @@ class TestIncrementalInsertQuotedColumnsAllCols:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-
 

--- a/tests/functional/adapter/incremental_materialization/quotes/test_quoted_columns_incremental_insert.py
+++ b/tests/functional/adapter/incremental_materialization/quotes/test_quoted_columns_incremental_insert.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/incremental_materialization/quotes/test_quotes_enabled_in_model.py
+++ b/tests/functional/adapter/incremental_materialization/quotes/test_quotes_enabled_in_model.py
@@ -145,4 +145,3 @@ class TestIncrementalMergeQuotedColumnsConfigYml:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-

--- a/tests/functional/adapter/incremental_materialization/quotes/test_quotes_enabled_in_model.py
+++ b/tests/functional/adapter/incremental_materialization/quotes/test_quotes_enabled_in_model.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/incremental_materialization/quotes/test_quotes_enabled_in_model.py
+++ b/tests/functional/adapter/incremental_materialization/quotes/test_quotes_enabled_in_model.py
@@ -77,6 +77,7 @@ SELECT * FROM dual
 class TestIncrementalMergeQuotedColumnsConfigYml:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
@@ -84,6 +85,7 @@ class TestIncrementalMergeQuotedColumnsConfigYml:
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_incr_model.sql": my_incr_model_sql,
@@ -91,6 +93,7 @@ class TestIncrementalMergeQuotedColumnsConfigYml:
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def project_config_update(self):
         return {
             "seeds": {
@@ -142,5 +145,4 @@ class TestIncrementalMergeQuotedColumnsConfigYml:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-
 

--- a/tests/functional/adapter/incremental_materialization/sync_schema/test_quote_special_characters_and_keywords.py
+++ b/tests/functional/adapter/incremental_materialization/sync_schema/test_quote_special_characters_and_keywords.py
@@ -70,6 +70,7 @@ ALTER TABLE {schema}.seed DROP ("birth_ date in yyyy-mm-dd") CASCADE CONSTRAINTS
 class TestSyncSchemaIncrementalMergeQuotedColumns:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
@@ -79,6 +80,7 @@ class TestSyncSchemaIncrementalMergeQuotedColumns:
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_incr_model.sql": my_incr_model_sql,
@@ -156,5 +158,4 @@ class TestSyncSchemaIncrementalMergeQuotedColumns:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-
 

--- a/tests/functional/adapter/incremental_materialization/sync_schema/test_quote_special_characters_and_keywords.py
+++ b/tests/functional/adapter/incremental_materialization/sync_schema/test_quote_special_characters_and_keywords.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/incremental_materialization/sync_schema/test_quote_special_characters_and_keywords.py
+++ b/tests/functional/adapter/incremental_materialization/sync_schema/test_quote_special_characters_and_keywords.py
@@ -158,4 +158,3 @@ class TestSyncSchemaIncrementalMergeQuotedColumns:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-

--- a/tests/functional/adapter/incremental_materialization/test_incremental_microbatch.py
+++ b/tests/functional/adapter/incremental_materialization/test_incremental_microbatch.py
@@ -21,6 +21,7 @@ from dbt.tests.adapter.incremental.test_incremental_microbatch import BaseMicrob
 
 class TestMicrobatch(BaseMicrobatch):
     @pytest.fixture(scope="class")
+    @classmethod
     def input_model_sql(self) -> str:
         return """
 {{ config(materialized='table', event_time='event_time') }}
@@ -32,6 +33,7 @@ select 3 as id, TIMESTAMP '2020-01-03 00:00:00' as event_time from dual
 """
 
     @pytest.fixture(scope="class")
+    @classmethod
     def insert_two_rows_sql(self, project) -> str:
         test_schema_relation = project.adapter.Relation.create(
             database=project.database, schema=project.test_schema

--- a/tests/functional/adapter/incremental_materialization/test_incremental_predicates.py
+++ b/tests/functional/adapter/incremental_materialization/test_incremental_predicates.py
@@ -45,12 +45,14 @@ select 3 as id, 'anyway' as msg, 'purple' as color from dual
 class TestIncrementalPredicatesMergeOracle(BaseIncrementalPredicates):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "delete_insert_incremental_predicates.sql": models__delete_insert_incremental_predicates_sql
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def project_config_update(self):
         return {
             "models": {
@@ -65,12 +67,14 @@ class TestIncrementalPredicatesMergeOracle(BaseIncrementalPredicates):
 class TestPredicatesMergeOracle(BaseIncrementalPredicates):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "delete_insert_incremental_predicates.sql": models__delete_insert_incremental_predicates_sql
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def project_config_update(self):
         return {
             "models": {

--- a/tests/functional/adapter/incremental_materialization/test_incremental_predicates.py
+++ b/tests/functional/adapter/incremental_materialization/test_incremental_predicates.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/incremental_materialization/test_merge_update_columns.py
+++ b/tests/functional/adapter/incremental_materialization/test_merge_update_columns.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,7 +133,6 @@ class TestIncrementalMergeUpdateColumns:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-
 
 
 

--- a/tests/functional/adapter/incremental_materialization/test_merge_update_columns.py
+++ b/tests/functional/adapter/incremental_materialization/test_merge_update_columns.py
@@ -137,4 +137,3 @@ class TestIncrementalMergeUpdateColumns:
 
 
 
-

--- a/tests/functional/adapter/incremental_materialization/test_merge_update_columns.py
+++ b/tests/functional/adapter/incremental_materialization/test_merge_update_columns.py
@@ -57,6 +57,7 @@ SELECT * FROM dual
 class TestIncrementalMergeUpdateColumns:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
@@ -64,6 +65,7 @@ class TestIncrementalMergeUpdateColumns:
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_incr_model.sql": my_incr_model_sql,
@@ -131,7 +133,6 @@ class TestIncrementalMergeUpdateColumns:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-
 
 
 

--- a/tests/functional/adapter/incremental_materialization/test_partition_config.py
+++ b/tests/functional/adapter/incremental_materialization/test_partition_config.py
@@ -51,10 +51,12 @@ models:
 
 class TestIncrementalPartitionConfig:
     @pytest.fixture(scope="class")
+    @classmethod
     def schema(self):
         return "test_incremental_partition_config"
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "incremental_model.sql": incremental_model_sql,

--- a/tests/functional/adapter/incremental_materialization/test_quotes_with_merge_update_columns.py
+++ b/tests/functional/adapter/incremental_materialization/test_quotes_with_merge_update_columns.py
@@ -138,4 +138,3 @@ class TestIncrementalMergeQuotedColumns:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-

--- a/tests/functional/adapter/incremental_materialization/test_quotes_with_merge_update_columns.py
+++ b/tests/functional/adapter/incremental_materialization/test_quotes_with_merge_update_columns.py
@@ -57,6 +57,7 @@ SELECT * FROM dual
 class TestIncrementalMergeQuotedColumns:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
@@ -64,6 +65,7 @@ class TestIncrementalMergeQuotedColumns:
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_incr_model.sql": my_incr_model_sql,
@@ -136,5 +138,4 @@ class TestIncrementalMergeQuotedColumns:
 
         result = project.run_sql(used_id_5_query, fetch="all")
         assert result == expected_result
-
 

--- a/tests/functional/adapter/incremental_materialization/test_quotes_with_merge_update_columns.py
+++ b/tests/functional/adapter/incremental_materialization/test_quotes_with_merge_update_columns.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/incremental_materialization/test_temp_relation_cleanup.py
+++ b/tests/functional/adapter/incremental_materialization/test_temp_relation_cleanup.py
@@ -55,10 +55,12 @@ models:
 
 class TestIncrementalTempRelationCleanup:
     @pytest.fixture(scope="class")
+    @classmethod
     def schema(self):
         return "test_temp_relation_cleanup"
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "failing_incremental.sql": failing_incremental_sql,

--- a/tests/functional/adapter/incremental_materialization/test_unique_id.py
+++ b/tests/functional/adapter/incremental_materialization/test_unique_id.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025, Oracle and/or its affiliates.
+Copyright (c) 2025, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/incremental_materialization/test_unique_id.py
+++ b/tests/functional/adapter/incremental_materialization/test_unique_id.py
@@ -110,6 +110,7 @@ select 'CO','Denver', null, TO_DATE('2021-06-18', 'YYYY-MM-DD') FROM DUAL
 class TestIncrementalUniqueKey(BaseIncrementalUniqueKey):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "trinary_unique_key_list.sql": models__trinary_unique_key_list_sql,
@@ -129,6 +130,7 @@ class TestIncrementalUniqueKey(BaseIncrementalUniqueKey):
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "duplicate_insert.sql": seeds__duplicate_insert_sql,

--- a/tests/functional/adapter/macros/test_alter_column_type.py
+++ b/tests/functional/adapter/macros/test_alter_column_type.py
@@ -49,18 +49,21 @@ class TestAlterColumnDataTypeMacro:
     """
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "my_seed.csv": my_seed_csv,
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model.sql": my_model_sql,
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def macros(self):
         return {"wrap_alter_column_type.sql": alter_column_type_wrapper_macro}
 
@@ -80,5 +83,4 @@ class TestAlterColumnDataTypeMacro:
                             ('NAME', 'CLOB', 0),
                             ('SOME_DATE', 'TIMESTAMP(6)', 0)]
         assert expected_columns == columns
-
 

--- a/tests/functional/adapter/macros/test_alter_column_type.py
+++ b/tests/functional/adapter/macros/test_alter_column_type.py
@@ -83,4 +83,3 @@ class TestAlterColumnDataTypeMacro:
                             ('NAME', 'CLOB', 0),
                             ('SOME_DATE', 'TIMESTAMP(6)', 0)]
         assert expected_columns == columns
-

--- a/tests/functional/adapter/macros/test_alter_column_type.py
+++ b/tests/functional/adapter/macros/test_alter_column_type.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/materialized_view/test_materialized_view.py
+++ b/tests/functional/adapter/materialized_view/test_materialized_view.py
@@ -153,6 +153,7 @@ class OracleMaterializedViewChanges(MaterializedViewChanges):
         set_model_file(project, my_materialized_view, initial_model)
 
     @pytest.fixture(scope="class", autouse=True)
+    @classmethod
     def models(self):
         yield {
             "my_table.sql": MY_TABLE,

--- a/tests/functional/adapter/materialized_view/test_materialized_view.py
+++ b/tests/functional/adapter/materialized_view/test_materialized_view.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tests/functional/adapter/simple_seed/test_simple_seed.py
+++ b/tests/functional/adapter/simple_seed/test_simple_seed.py
@@ -22,6 +22,7 @@ from dbt.tests.util import run_dbt
 
 class TestSimpleBigSeedBatched(SeedConfigBase):
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         seed_data = ["seed_id"]
         seed_data.extend([str(i) for i in range(20_000)])

--- a/tests/functional/adapter/simple_seed/test_simple_seed.py
+++ b/tests/functional/adapter/simple_seed/test_simple_seed.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tests/functional/adapter/snapshots/test_invalidate_deletes.py
+++ b/tests/functional/adapter/snapshots/test_invalidate_deletes.py
@@ -68,6 +68,7 @@ DELETE FROM {schema}.seed WHERE id = 2
 class TestSnapshotCheckInvalidateHardDeletes:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": my_seed_csv,
@@ -78,6 +79,7 @@ class TestSnapshotCheckInvalidateHardDeletes:
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def snapshots(self):
         return {
             "cc_all_snapshot.sql": cc_all_snapshot_sql,
@@ -126,6 +128,5 @@ class TestSnapshotCheckInvalidateHardDeletes:
         # Deleted record will be invalidated. r['dbt_valid_to'] is set to current timestamp.
         snapshot_of_deleted_rows = project.run_sql(f"select * from cc_all_snapshot where id=2", fetch="all")
         assert len(snapshot_of_deleted_rows) == 1
-
 
 

--- a/tests/functional/adapter/snapshots/test_invalidate_deletes.py
+++ b/tests/functional/adapter/snapshots/test_invalidate_deletes.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025, Oracle and/or its affiliates.
+Copyright (c) 2025, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -128,4 +128,3 @@ class TestSnapshotCheckInvalidateHardDeletes:
         # Deleted record will be invalidated. r['dbt_valid_to'] is set to current timestamp.
         snapshot_of_deleted_rows = project.run_sql(f"select * from cc_all_snapshot where id=2", fetch="all")
         assert len(snapshot_of_deleted_rows) == 1
-

--- a/tests/functional/adapter/snapshots/test_invalidate_deletes.py
+++ b/tests/functional/adapter/snapshots/test_invalidate_deletes.py
@@ -129,4 +129,3 @@ class TestSnapshotCheckInvalidateHardDeletes:
         snapshot_of_deleted_rows = project.run_sql(f"select * from cc_all_snapshot where id=2", fetch="all")
         assert len(snapshot_of_deleted_rows) == 1
 
-

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,7 @@ from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_singular_tests import BaseSingularTests
 from dbt.tests.adapter.basic.test_singular_tests_ephemeral import BaseSingularTestsEphemeral
 from dbt.tests.adapter.basic.test_empty import BaseEmpty
+from dbt.tests.adapter.empty.test_empty import BaseTestEmptySeedFlag
 from dbt.tests.adapter.basic.test_ephemeral import BaseEphemeral
 from dbt.tests.adapter.basic.test_incremental import BaseIncremental, BaseIncrementalNotSchemaChange
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
@@ -176,6 +177,12 @@ class TestSingularTestsEphemeralOracle(BaseSingularTestsEphemeral):
 
 
 class TestEmptyOracle(BaseEmpty):
+    pass
+
+
+class TestEmptySeedFlagOracle(BaseTestEmptySeedFlag):
+    """Verify that ``dbt seed --empty`` creates Oracle seed tables without rows."""
+
     pass
 
 

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -154,6 +154,7 @@ class TestSimpleMaterializationsOracle(BaseSimpleMaterializations):
 class TestSingularTestsOracle(BaseSingularTests):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def tests(self):
         return {
             "passing.sql": test_passing_sql,
@@ -164,6 +165,7 @@ class TestSingularTestsOracle(BaseSingularTests):
 class TestSingularTestsEphemeralOracle(BaseSingularTestsEphemeral):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "ephemeral.sql": config_materialized_ephemeral + model_ephemeral,
@@ -192,6 +194,7 @@ class TestGenericTestsOracle(BaseGenericTests):
 class TestSnapshotCheckColsOracle(BaseSnapshotCheckCols):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def snapshots(self):
         return {
             "cc_all_snapshot.sql": cc_all_snapshot_sql,
@@ -203,6 +206,7 @@ class TestSnapshotCheckColsOracle(BaseSnapshotCheckCols):
 class TestSnapshotTimestampOracle(BaseSnapshotTimestamp):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def snapshots(self):
         return {
             "ts_snapshot.sql": ts_snapshot_sql,
@@ -212,6 +216,7 @@ class TestSnapshotTimestampOracle(BaseSnapshotTimestamp):
 class TestBaseAdapterMethodOracle(BaseAdapterMethod):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "upstream.sql": models__upstream_sql,
@@ -223,5 +228,6 @@ class TestBaseAdapterMethodOracle(BaseAdapterMethod):
 class TestIncrementalNotSchemaChangeOracle(BaseIncrementalNotSchemaChange):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {"incremental_not_schema_change.sql": incremental_not_schema_change_sql}

--- a/tests/functional/adapter/test_caching.py
+++ b/tests/functional/adapter/test_caching.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tests/functional/adapter/test_caching.py
+++ b/tests/functional/adapter/test_caching.py
@@ -69,6 +69,7 @@ class OracleBaseCaching(BaseCachingTest):
 class TestCachingLowerCaseModel(OracleBaseCaching):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "model.sql": model_sql,
@@ -78,6 +79,7 @@ class TestCachingLowerCaseModel(OracleBaseCaching):
 class TestCachingUppercaseModel(OracleBaseCaching):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "MODEL.sql": model_sql,
@@ -87,6 +89,7 @@ class TestCachingUppercaseModel(OracleBaseCaching):
 class TestCachingSelectedSchemaOnly(OracleBaseCaching):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "model.sql": model_sql,

--- a/tests/functional/adapter/test_data_types.py
+++ b/tests/functional/adapter/test_data_types.py
@@ -56,6 +56,7 @@ select cast('1' as {{ type_boolean() }}) as boolean_col from dual
 class TestTypeBigIntOracle(BaseTypeBigInt):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "expected.sql": models__bigint_expected_sql,
@@ -66,6 +67,7 @@ class TestTypeBigIntOracle(BaseTypeBigInt):
 class TestTypeFloatOracle(BaseTypeFloat):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {"actual.sql": self.interpolate_macro_namespace(models__float_actual_sql, "type_float")}
 
@@ -73,6 +75,7 @@ class TestTypeFloatOracle(BaseTypeFloat):
 class TestTypeIntOracle(BaseTypeInt):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {"actual.sql": self.interpolate_macro_namespace(models__int_actual_sql, "type_int")}
 
@@ -80,6 +83,7 @@ class TestTypeIntOracle(BaseTypeInt):
 class TestTypeNumericOracle(BaseTypeNumeric):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {"actual.sql": self.interpolate_macro_namespace(models__numeric_actual_sql, "type_numeric")}
 
@@ -87,10 +91,11 @@ class TestTypeNumericOracle(BaseTypeNumeric):
 class TestTypeBooleanOracle(BaseTypeBoolean):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {"expected.csv": seeds__boolean_expected_csv}
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {"actual.sql": self.interpolate_macro_namespace(models__boolean_actual_sql, "type_boolean")}
-

--- a/tests/functional/adapter/test_data_types.py
+++ b/tests/functional/adapter/test_data_types.py
@@ -60,7 +60,7 @@ class TestTypeBigIntOracle(BaseTypeBigInt):
     def models(self):
         return {
             "expected.sql": models__bigint_expected_sql,
-            "actual.sql": self.interpolate_macro_namespace(models__bigint_actual_sql, "type_bigint"),
+            "actual.sql": self().interpolate_macro_namespace(models__bigint_actual_sql, "type_bigint"),
         }
 
 
@@ -68,24 +68,24 @@ class TestTypeFloatOracle(BaseTypeFloat):
 
     @pytest.fixture(scope="class")
     @classmethod
-    def models(self):
-        return {"actual.sql": self.interpolate_macro_namespace(models__float_actual_sql, "type_float")}
+    def models(cls):
+        return {"actual.sql": cls().interpolate_macro_namespace(models__float_actual_sql, "type_float")}
 
 
 class TestTypeIntOracle(BaseTypeInt):
 
     @pytest.fixture(scope="class")
     @classmethod
-    def models(self):
-        return {"actual.sql": self.interpolate_macro_namespace(models__int_actual_sql, "type_int")}
+    def models(cls):
+        return {"actual.sql": cls().interpolate_macro_namespace(models__int_actual_sql, "type_int")}
 
 
 class TestTypeNumericOracle(BaseTypeNumeric):
 
     @pytest.fixture(scope="class")
     @classmethod
-    def models(self):
-        return {"actual.sql": self.interpolate_macro_namespace(models__numeric_actual_sql, "type_numeric")}
+    def models(cls):
+        return {"actual.sql": cls().interpolate_macro_namespace(models__numeric_actual_sql, "type_numeric")}
 
 
 class TestTypeBooleanOracle(BaseTypeBoolean):
@@ -98,4 +98,4 @@ class TestTypeBooleanOracle(BaseTypeBoolean):
     @pytest.fixture(scope="class")
     @classmethod
     def models(self):
-        return {"actual.sql": self.interpolate_macro_namespace(models__boolean_actual_sql, "type_boolean")}
+        return {"actual.sql": self().interpolate_macro_namespace(models__boolean_actual_sql, "type_boolean")}

--- a/tests/functional/adapter/test_data_types.py
+++ b/tests/functional/adapter/test_data_types.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/test_dbt_show.py
+++ b/tests/functional/adapter/test_dbt_show.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tests/functional/adapter/test_dbt_show.py
+++ b/tests/functional/adapter/test_dbt_show.py
@@ -52,6 +52,7 @@ class TestOracleShowLimit(BaseShowLimit):
 class TestOracleShowSqlHeader(BaseShowSqlHeader):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "sql_header.sql": models__sql_header,

--- a/tests/functional/adapter/test_docs_generate.py
+++ b/tests/functional/adapter/test_docs_generate.py
@@ -1,3 +1,19 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+"""
+
 import pytest
 
 from dbt.tests.adapter.basic.test_docs_generate import (models__schema_yml,

--- a/tests/functional/adapter/test_docs_generate.py
+++ b/tests/functional/adapter/test_docs_generate.py
@@ -148,6 +148,7 @@ def base_expected_catalog(
 class TestOracleDocsGenerate(BaseDocsGenerate):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "schema.yml": models__schema_yml,
@@ -157,6 +158,7 @@ class TestOracleDocsGenerate(BaseDocsGenerate):
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def expected_catalog(self, project, profile_user):
         return base_expected_catalog(
             project,
@@ -172,6 +174,7 @@ class TestOracleDocsGenerate(BaseDocsGenerate):
         )
 
     @pytest.fixture(scope="class")
+    @classmethod
     def project_config_update(self, unique_schema):
         alternate_schema = unique_schema
         return {

--- a/tests/functional/adapter/test_docs_genreferences.py
+++ b/tests/functional/adapter/test_docs_genreferences.py
@@ -1,3 +1,19 @@
+"""
+Copyright (c) 2026, Oracle and/or its affiliates.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+"""
+
 import pytest
 
 from dbt.tests.adapter.basic.test_docs_generate import (BaseDocsGenReferences,

--- a/tests/functional/adapter/test_docs_genreferences.py
+++ b/tests/functional/adapter/test_docs_genreferences.py
@@ -198,6 +198,7 @@ def expected_references_catalog(
 class TestOracleDocsGenReferences(BaseDocsGenReferences):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "schema.yml": ref_models__schema_yml,
@@ -209,6 +210,7 @@ class TestOracleDocsGenReferences(BaseDocsGenReferences):
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def project_config_update(self, unique_schema):
         alternate_schema = unique_schema
         return {
@@ -224,6 +226,7 @@ class TestOracleDocsGenReferences(BaseDocsGenReferences):
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def expected_catalog(self, project, profile_user):
         return expected_references_catalog(
             project,

--- a/tests/functional/adapter/test_generictests_where.py
+++ b/tests/functional/adapter/test_generictests_where.py
@@ -65,6 +65,7 @@ models:
 class TestGenericTestsOracle(BaseGenericTests):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "base.csv": seeds_base_csv,
@@ -72,6 +73,7 @@ class TestGenericTestsOracle(BaseGenericTests):
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "view_model.sql": base_view_sql,

--- a/tests/functional/adapter/test_generictests_where.py
+++ b/tests/functional/adapter/test_generictests_where.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/test_get_last_relation_modified.py
+++ b/tests/functional/adapter/test_get_last_relation_modified.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tests/functional/adapter/test_get_last_relation_modified.py
+++ b/tests/functional/adapter/test_get_last_relation_modified.py
@@ -33,16 +33,19 @@ sources:
 
 class TestGetLastRelationModified:
     @pytest.fixture(scope="class", autouse=True)
+    @classmethod
     def set_env_vars(self, project):
         os.environ["DBT_GET_LAST_RELATION_TEST_SCHEMA"] = project.test_schema
         yield
         del os.environ["DBT_GET_LAST_RELATION_TEST_SCHEMA"]
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {"schema.yml": freshness_via_metadata_schema_yml}
 
     @pytest.fixture(scope="class")
+    @classmethod
     def custom_schema(self, project, set_env_vars):
         with project.adapter.connection_named("__test"):
             relation = project.adapter.Relation.create(

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -53,6 +53,7 @@ class TestSeedGrantsOracle(BaseSeedGrants):
 class TestModelGrantsOracle(BaseModelGrants):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         updated_schema = self.interpolate_name_overrides(model_schema_yml)
 
@@ -65,6 +66,7 @@ class TestModelGrantsOracle(BaseModelGrants):
 class TestIncrementalGrantsOracle(BaseIncrementalGrants):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         updated_schema = self.interpolate_name_overrides(incremental_model_schema_yml)
         return {
@@ -82,6 +84,7 @@ class TestInvalidGrantsOracle(BaseInvalidGrants):
         return "ORA-00990: missing or invalid privilege"
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_invalid_model.sql": my_invalid_model_sql,
@@ -91,6 +94,7 @@ class TestInvalidGrantsOracle(BaseInvalidGrants):
 class TestSnapshotGrantsOracle(BaseSnapshotGrants):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def snapshots(self):
         return {
             "my_snapshot.sql": my_snapshot_sql,

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -55,7 +55,7 @@ class TestModelGrantsOracle(BaseModelGrants):
     @pytest.fixture(scope="class")
     @classmethod
     def models(self):
-        updated_schema = self.interpolate_name_overrides(model_schema_yml)
+        updated_schema = self().interpolate_name_overrides(model_schema_yml)
 
         return {
             "my_model.sql": my_model_sql,
@@ -68,7 +68,7 @@ class TestIncrementalGrantsOracle(BaseIncrementalGrants):
     @pytest.fixture(scope="class")
     @classmethod
     def models(self):
-        updated_schema = self.interpolate_name_overrides(incremental_model_schema_yml)
+        updated_schema = self().interpolate_name_overrides(incremental_model_schema_yml)
         return {
             "my_incremental_model.sql": my_incremental_model_sql,
             "schema.yml": updated_schema,
@@ -98,5 +98,5 @@ class TestSnapshotGrantsOracle(BaseSnapshotGrants):
     def snapshots(self):
         return {
             "my_snapshot.sql": my_snapshot_sql,
-            "schema.yml": self.interpolate_name_overrides(snapshot_schema_yml),
+            "schema.yml": self().interpolate_name_overrides(snapshot_schema_yml),
         }

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/test_quoted_relations.py
+++ b/tests/functional/adapter/test_quoted_relations.py
@@ -49,18 +49,21 @@ SELECT * FROM {{ ref('seed') }}
 class TestQuotedLowerCaseTableName:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model_foo.sql": my_model_foo_sql,
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def project_config_update(self):
         return {
             "quoting": {
@@ -93,18 +96,21 @@ class TestQuotedLowerCaseTableName:
 class TestQuotedTitleCaseTableName:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model_foo.sql": my_model_foo2_sql,
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def project_config_update(self):
         return {
             "quoting": {
@@ -137,12 +143,14 @@ class TestQuotedTitleCaseTableName:
 class TestUnQuotedLowerCaseTableName:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model_foo.sql": my_model_foo_sql,
@@ -171,12 +179,14 @@ class TestUnQuotedLowerCaseTableName:
 class TestUnQuotedTitleCaseTableName:
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {
             "seed.csv": seed_csv,
         }
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "my_model_foo.sql": my_model_foo2_sql,
@@ -200,5 +210,4 @@ class TestUnQuotedTitleCaseTableName:
         sql = 'SELECT COUNT(*) from FOO'
         result = project.run_sql(sql, fetch="all")
         assert result == [(4,)]
-
 

--- a/tests/functional/adapter/test_quoted_relations.py
+++ b/tests/functional/adapter/test_quoted_relations.py
@@ -210,4 +210,3 @@ class TestUnQuotedTitleCaseTableName:
         sql = 'SELECT COUNT(*) from FOO'
         result = project.run_sql(sql, fetch="all")
         assert result == [(4,)]
-

--- a/tests/functional/adapter/test_quoted_relations.py
+++ b/tests/functional/adapter/test_quoted_relations.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/utils/test_common_utils.py
+++ b/tests/functional/adapter/utils/test_common_utils.py
@@ -115,6 +115,7 @@ select {{ dbt.current_timestamp() }} as current_ts_column from dual
 class TestCastBoolToText(BaseCastBoolToText):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "test_cast_bool_to_text.yml": models__test_cast_bool_to_text_yml,
@@ -135,6 +136,7 @@ class TestConcat(BaseConcat):
 class TestEscapeSingleQuotesQuote(BaseEscapeSingleQuotesQuote):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "test_escape_single_quotes.yml": models__test_escape_single_quotes_yml,
@@ -151,6 +153,7 @@ class TestExcept(BaseExcept):
 class TestHash(BaseHash):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {"data_hash.csv": seeds__data_hash_csv}
 
@@ -158,6 +161,7 @@ class TestHash(BaseHash):
 class TestStringLiteral(BaseStringLiteral):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "test_string_literal.yml": models__test_string_literal_yml,
@@ -178,6 +182,7 @@ class TestStringRight(BaseRight):
 class TestStringReplace(BaseReplace):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "test_replace.yml": models__test_replace_yml,
@@ -194,8 +199,8 @@ class TestStringLength(BaseLength):
 class TestCurrentTimestampNaiveOracle(BaseCurrentTimestampNaive):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "current_ts.sql": models__current_ts_sql,
         }
-

--- a/tests/functional/adapter/utils/test_common_utils.py
+++ b/tests/functional/adapter/utils/test_common_utils.py
@@ -119,7 +119,7 @@ class TestCastBoolToText(BaseCastBoolToText):
     def models(self):
         return {
             "test_cast_bool_to_text.yml": models__test_cast_bool_to_text_yml,
-            "test_cast_bool_to_text.sql": self.interpolate_macro_namespace(
+            "test_cast_bool_to_text.sql": self().interpolate_macro_namespace(
                 models__test_cast_bool_to_text_sql, "cast_bool_to_text"
             ),
         }
@@ -140,7 +140,7 @@ class TestEscapeSingleQuotesQuote(BaseEscapeSingleQuotesQuote):
     def models(self):
         return {
             "test_escape_single_quotes.yml": models__test_escape_single_quotes_yml,
-            "test_escape_single_quotes.sql": self.interpolate_macro_namespace(
+            "test_escape_single_quotes.sql": self().interpolate_macro_namespace(
                 models__test_escape_single_quotes_quote_sql, "escape_single_quotes"
             ),
         }
@@ -165,7 +165,7 @@ class TestStringLiteral(BaseStringLiteral):
     def models(self):
         return {
             "test_string_literal.yml": models__test_string_literal_yml,
-            "test_string_literal.sql": self.interpolate_macro_namespace(
+            "test_string_literal.sql": self().interpolate_macro_namespace(
                 models__test_string_literal_sql, "string_literal"
             ),
         }
@@ -186,7 +186,7 @@ class TestStringReplace(BaseReplace):
     def models(self):
         return {
             "test_replace.yml": models__test_replace_yml,
-            "test_replace.sql": self.interpolate_macro_namespace(
+            "test_replace.sql": self().interpolate_macro_namespace(
                 models__test_replace_sql, "replace"
             ),
         }

--- a/tests/functional/adapter/utils/test_common_utils.py
+++ b/tests/functional/adapter/utils/test_common_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/utils/test_date_spine.py
+++ b/tests/functional/adapter/utils/test_date_spine.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/tests/functional/adapter/utils/test_date_spine.py
+++ b/tests/functional/adapter/utils/test_date_spine.py
@@ -51,6 +51,7 @@ left join expected_dates on generated_dates.date_day = expected_dates.expected
 
 class BaseDateSpine(BaseUtils):
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "test_date_spine.yml": models__test_date_spine_yml,
@@ -62,4 +63,3 @@ class BaseDateSpine(BaseUtils):
 
 class TestDateSpine(BaseDateSpine):
     pass
-

--- a/tests/functional/adapter/utils/test_date_spine.py
+++ b/tests/functional/adapter/utils/test_date_spine.py
@@ -55,7 +55,7 @@ class BaseDateSpine(BaseUtils):
     def models(self):
         return {
             "test_date_spine.yml": models__test_date_spine_yml,
-            "test_date_spine.sql": self.interpolate_macro_namespace(
+            "test_date_spine.sql": self().interpolate_macro_namespace(
                 models__test_date_spine_sql, "date_spine"
             ),
         }

--- a/tests/functional/adapter/utils/test_dateutils.py
+++ b/tests/functional/adapter/utils/test_dateutils.py
@@ -141,10 +141,12 @@ union all
 class TestDateAdd(BaseDateAdd):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {"data_dateadd.csv": seeds__data_dateadd_csv}
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "test_dateadd.yml": models__test_dateadd_yml,
@@ -157,6 +159,7 @@ class TestDateAdd(BaseDateAdd):
 class TestDateTrunc(BaseDateTrunc):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {"data_date_trunc.csv": seeds__data_date_trunc_csv}
 
@@ -168,10 +171,12 @@ class TestLastDay(BaseLastDay):
 class TestDateDiff(BaseDateDiff):
 
     @pytest.fixture(scope="class")
+    @classmethod
     def seeds(self):
         return {"data_datediff.csv": seeds__data_datediff_csv}
 
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "test_datediff.yml": models__test_datediff_yml,

--- a/tests/functional/adapter/utils/test_dateutils.py
+++ b/tests/functional/adapter/utils/test_dateutils.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2022, 2026, Oracle and/or its affiliates.
 Copyright (c) 2020, Vitor Avancini
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/functional/adapter/utils/test_dateutils.py
+++ b/tests/functional/adapter/utils/test_dateutils.py
@@ -150,7 +150,7 @@ class TestDateAdd(BaseDateAdd):
     def models(self):
         return {
             "test_dateadd.yml": models__test_dateadd_yml,
-            "test_dateadd.sql": self.interpolate_macro_namespace(
+            "test_dateadd.sql": self().interpolate_macro_namespace(
                 models__test_dateadd_sql, "dateadd"
             ),
         }
@@ -180,7 +180,7 @@ class TestDateDiff(BaseDateDiff):
     def models(self):
         return {
             "test_datediff.yml": models__test_datediff_yml,
-            "test_datediff.sql": self.interpolate_macro_namespace(
+            "test_datediff.sql": self().interpolate_macro_namespace(
                 models__test_datediff_sql, "datediff"
             ),
         }

--- a/tests/functional/adapter/utils/test_generate_series.py
+++ b/tests/functional/adapter/utils/test_generate_series.py
@@ -60,7 +60,7 @@ class BaseGenerateSeries(BaseUtils):
     def models(self):
         return {
             "test_generate_series.yml": models__test_generate_series_yml,
-            "test_generate_series.sql": self.interpolate_macro_namespace(
+            "test_generate_series.sql": self().interpolate_macro_namespace(
                 models__test_generate_series_sql, "generate_series"
             ),
         }

--- a/tests/functional/adapter/utils/test_generate_series.py
+++ b/tests/functional/adapter/utils/test_generate_series.py
@@ -56,6 +56,7 @@ SELECT * from joined
 
 class BaseGenerateSeries(BaseUtils):
     @pytest.fixture(scope="class")
+    @classmethod
     def models(self):
         return {
             "test_generate_series.yml": models__test_generate_series_yml,

--- a/tests/functional/adapter/utils/test_generate_series.py
+++ b/tests/functional/adapter/utils/test_generate_series.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) 2023, 2026, Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Uptake dbt-core v1.12.0
- Use adb-free for CI
- Test changes to handle class-scoped fixtures 
- Support for Python 3.14
- Added tests for `dbt seed --empty` to create a table empty rows